### PR TITLE
feat(#0y0): NVS config store

### DIFF
--- a/firmware/include/config_store.h
+++ b/firmware/include/config_store.h
@@ -1,0 +1,36 @@
+/**
+ * NVS Config Store — Persistent device settings
+ * Uses Arduino Preferences (ESP-IDF NVS) for flash storage.
+ */
+
+#pragma once
+#include <Arduino.h>
+
+static constexpr uint8_t  DCC_MAX_WIFI       = 5;
+static constexpr uint8_t  DCC_SSID_LEN       = 33;
+static constexpr uint8_t  DCC_PASS_LEN       = 65;
+static constexpr uint8_t  DCC_URL_LEN        = 128;
+static constexpr uint8_t  DCC_TZ_LEN         = 48;
+
+struct WifiEntry {
+    char ssid[DCC_SSID_LEN];
+    char password[DCC_PASS_LEN];
+    uint8_t priority;           // 0 = highest
+};
+
+struct DeviceConfig {
+    WifiEntry wifi[DCC_MAX_WIFI];
+    uint8_t   wifi_count;
+    char      bridge_url[DCC_URL_LEN];
+    char      timezone[DCC_TZ_LEN];
+    uint8_t   brightness;       // 0x05..0x10 (STC8H1K28 range)
+    bool      clock_24h;
+    uint16_t  poll_interval_sec;
+};
+
+namespace ConfigStore {
+    void init();
+    DeviceConfig load();
+    void save(const DeviceConfig& cfg);
+    void reset();
+}

--- a/firmware/src/config_store.cpp
+++ b/firmware/src/config_store.cpp
@@ -1,0 +1,109 @@
+/**
+ * NVS Config Store — Implementation
+ * Uses Arduino Preferences for typed key-value persistence.
+ * NVS key names are max 15 chars.
+ */
+
+#include "config_store.h"
+#include <Preferences.h>
+
+static Preferences prefs;
+static const char* NVS_NAMESPACE = "dcc_cfg";
+
+/* Defaults */
+static constexpr const char* DEFAULT_BRIDGE  = "genx2k.dynu.net";
+static constexpr const char* DEFAULT_TZ      = "EST5EDT,M3.2.0,M11.1.0";
+static constexpr uint8_t     DEFAULT_BRIGHT  = 0x10;
+static constexpr bool        DEFAULT_24H     = false;
+static constexpr uint16_t    DEFAULT_POLL    = 30;
+
+/* NVS keys (max 15 chars) */
+static const char* KEY_WIFI_COUNT  = "wifi_count";
+static const char* KEY_BRIDGE      = "bridge_url";
+static const char* KEY_TZ          = "timezone";
+static const char* KEY_BRIGHT      = "brightness";
+static const char* KEY_24H         = "clock_24h";
+static const char* KEY_POLL        = "poll_sec";
+
+/* WiFi entries stored as wifi_s0..wifi_s4 (ssid), wifi_p0..wifi_p4 (pass), wifi_r0..wifi_r4 (priority) */
+static void loadWifi(DeviceConfig& cfg) {
+    cfg.wifi_count = prefs.getUChar(KEY_WIFI_COUNT, 0);
+    if (cfg.wifi_count > DCC_MAX_WIFI) cfg.wifi_count = DCC_MAX_WIFI;
+
+    for (uint8_t i = 0; i < DCC_MAX_WIFI; i++) {
+        char key_s[10], key_p[10], key_r[10];
+        snprintf(key_s, sizeof(key_s), "wifi_s%d", i);
+        snprintf(key_p, sizeof(key_p), "wifi_p%d", i);
+        snprintf(key_r, sizeof(key_r), "wifi_r%d", i);
+
+        if (i < cfg.wifi_count) {
+            prefs.getString(key_s, cfg.wifi[i].ssid, DCC_SSID_LEN);
+            prefs.getString(key_p, cfg.wifi[i].password, DCC_PASS_LEN);
+            cfg.wifi[i].priority = prefs.getUChar(key_r, i);
+        } else {
+            cfg.wifi[i].ssid[0] = '\0';
+            cfg.wifi[i].password[0] = '\0';
+            cfg.wifi[i].priority = i;
+        }
+    }
+}
+
+static void saveWifi(const DeviceConfig& cfg) {
+    prefs.putUChar(KEY_WIFI_COUNT, cfg.wifi_count);
+
+    for (uint8_t i = 0; i < cfg.wifi_count; i++) {
+        char key_s[10], key_p[10], key_r[10];
+        snprintf(key_s, sizeof(key_s), "wifi_s%d", i);
+        snprintf(key_p, sizeof(key_p), "wifi_p%d", i);
+        snprintf(key_r, sizeof(key_r), "wifi_r%d", i);
+
+        prefs.putString(key_s, cfg.wifi[i].ssid);
+        prefs.putString(key_p, cfg.wifi[i].password);
+        prefs.putUChar(key_r, cfg.wifi[i].priority);
+    }
+}
+
+void ConfigStore::init() {
+    prefs.begin(NVS_NAMESPACE, false);
+    Serial.println("CFG: NVS namespace opened");
+}
+
+DeviceConfig ConfigStore::load() {
+    DeviceConfig cfg = {};
+
+    loadWifi(cfg);
+    prefs.getString(KEY_BRIDGE, cfg.bridge_url, DCC_URL_LEN);
+    prefs.getString(KEY_TZ, cfg.timezone, DCC_TZ_LEN);
+    cfg.brightness       = prefs.getUChar(KEY_BRIGHT, DEFAULT_BRIGHT);
+    cfg.clock_24h        = prefs.getBool(KEY_24H, DEFAULT_24H);
+    cfg.poll_interval_sec = prefs.getUShort(KEY_POLL, DEFAULT_POLL);
+
+    /* Apply defaults for empty strings */
+    if (cfg.bridge_url[0] == '\0') {
+        strncpy(cfg.bridge_url, DEFAULT_BRIDGE, DCC_URL_LEN - 1);
+    }
+    if (cfg.timezone[0] == '\0') {
+        strncpy(cfg.timezone, DEFAULT_TZ, DCC_TZ_LEN - 1);
+    }
+
+    Serial.printf("CFG: loaded — bridge=%s tz=%s bright=0x%02X poll=%ds wifi=%d\n",
+                  cfg.bridge_url, cfg.timezone, cfg.brightness,
+                  cfg.poll_interval_sec, cfg.wifi_count);
+    return cfg;
+}
+
+void ConfigStore::save(const DeviceConfig& cfg) {
+    saveWifi(cfg);
+    prefs.putString(KEY_BRIDGE, cfg.bridge_url);
+    prefs.putString(KEY_TZ, cfg.timezone);
+    prefs.putUChar(KEY_BRIGHT, cfg.brightness);
+    prefs.putBool(KEY_24H, cfg.clock_24h);
+    prefs.putUShort(KEY_POLL, cfg.poll_interval_sec);
+
+    Serial.println("CFG: saved to NVS");
+}
+
+void ConfigStore::reset() {
+    prefs.clear();
+    Serial.println("CFG: factory reset — NVS cleared");
+}

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -9,6 +9,7 @@
 #include <Arduino.h>
 #include <lvgl.h>
 #include "display_driver.h"
+#include "config_store.h"
 
 static LGFX lcd;
 static lv_disp_draw_buf_t draw_buf;
@@ -46,6 +47,10 @@ static void lvglTouchRead(lv_indev_drv_t* drv, lv_indev_data_t* data) {
 void setup() {
     Serial.begin(115200);
     Serial.println("DCC: starting...");
+
+    /* Init config store */
+    ConfigStore::init();
+    DeviceConfig cfg = ConfigStore::load();
 
     /* Init display */
     lcd.begin();


### PR DESCRIPTION
## Summary
- `DeviceConfig` struct with WiFi credentials (5 networks), bridge URL, timezone, brightness, clock format, poll interval
- Arduino `Preferences`-based NVS persistence with typed keys (15-char limit)
- First-boot defaults: bridge=genx2k.dynu.net, tz=EST5EDT, brightness=max, poll=30s
- Factory reset via `ConfigStore::reset()`
- Integrated into `main.cpp` — config loads at boot before display init

## Test plan
- [ ] Flash to CrowPanel, verify default config prints on first boot
- [ ] Modify config via Serial, reboot, verify persistence
- [ ] Factory reset clears all keys

Closes #14

Generated with [Claude Code](https://claude.ai/claude-code)