### PR TITLE
feat(#368,#fpn): Wire all screens — fully navigable firmware

### DIFF
--- a/firmware/include/ui/screens/claude_screen.h
+++ b/firmware/include/ui/screens/claude_screen.h
@@ -1,0 +1,21 @@
+/**
+ * Claude Activity Screen — Agent session status display.
+ * Shows agent status, current task, and last activity time.
+ */
+
+#pragma once
+#include "ui/base_screen.h"
+
+class ClaudeScreen : public BaseScreen {
+public:
+    void create(lv_obj_t* parent) override;
+    void update(const DashboardData& data) override;
+
+private:
+    lv_obj_t* _lblStatus    = nullptr;
+    lv_obj_t* _statusDot    = nullptr;
+    lv_obj_t* _lblTask      = nullptr;
+    lv_obj_t* _lblBeadsOpen = nullptr;
+    lv_obj_t* _lblBeadsIP   = nullptr;
+    lv_obj_t* _lblBeadsBlk  = nullptr;
+};

--- a/firmware/include/ui/screens/diagnostics_screen.h
+++ b/firmware/include/ui/screens/diagnostics_screen.h
@@ -1,0 +1,36 @@
+/**
+ * Diagnostics Screen — System health and debug info.
+ * FW version, heap/PSRAM, WiFi, per-source sync status.
+ */
+
+#pragma once
+#include "ui/base_screen.h"
+
+class DiagnosticsScreen : public BaseScreen {
+public:
+    void create(lv_obj_t* parent) override;
+    void update(const DashboardData& data) override;
+    void onShow() override;
+
+private:
+    /* System info */
+    lv_obj_t* _lblVersion   = nullptr;
+    lv_obj_t* _lblHeap      = nullptr;
+    lv_obj_t* _lblPSRAM     = nullptr;
+    lv_obj_t* _lblUptime    = nullptr;
+
+    /* WiFi info */
+    lv_obj_t* _lblWifiSSID  = nullptr;
+    lv_obj_t* _lblWifiIP    = nullptr;
+    lv_obj_t* _lblWifiRSSI  = nullptr;
+
+    /* Data sources */
+    lv_obj_t* _lblLastFetch = nullptr;
+    lv_obj_t* _lblFetchErr  = nullptr;
+
+    lv_timer_t* _refreshTimer = nullptr;
+
+    void refreshSystemInfo();
+
+    static void onRefreshTimer(lv_timer_t* timer);
+};

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -2,8 +2,8 @@
  * Desk Command Center — Main Entry Point
  * CrowPanel Advance 5.0" (ESP32-S3-WROOM-1-N16R8)
  *
- * Task 1.1: Compiles clean with display + LVGL initialized.
- * No UI yet — that comes in tasks 1.2–1.5.
+ * Boot sequence: Config → Display → LVGL → Splash → Backlight →
+ *                WiFi → NTP → DataService → UI screens → Home
  */
 
 #include <Arduino.h>
@@ -14,7 +14,26 @@
 #include "backlight.h"
 #include "ntp_time.h"
 #include "data_service.h"
+#include "dashboard_data.h"
+#include "staleness_tracker.h"
+#include "error_state.h"
+
+/* UI */
 #include "ui/splash_screen.h"
+#include "ui/status_bar.h"
+#include "ui/nav_bar.h"
+#include "ui/osk.h"
+#include "ui/screen_manager.h"
+#include "ui/home_screen.h"
+#include "ui/screens/calendar_screen.h"
+#include "ui/screens/tasks_screen.h"
+#include "ui/screens/weather_screen.h"
+#include "ui/screens/devops_screen.h"
+#include "ui/screens/ha_screen.h"
+#include "ui/screens/claude_screen.h"
+#include "ui/screens/wifi_settings_screen.h"
+#include "ui/screens/settings_screen.h"
+#include "ui/screens/diagnostics_screen.h"
 
 static LGFX lcd;
 static lv_disp_draw_buf_t draw_buf;
@@ -25,7 +44,22 @@ static lv_indev_drv_t indev_drv;
 static constexpr uint32_t BUF_LINES = 40;
 static lv_color_t* buf1 = nullptr;
 static lv_color_t* buf2 = nullptr;
-static SplashScreen splash;
+
+/* Screens — allocated once, never destroyed */
+static SplashScreen         splash;
+static HomeScreen           homeScreen;
+static CalendarScreen       calendarScreen;
+static TasksScreen          tasksScreen;
+static WeatherScreen        weatherScreen;
+static DevOpsScreen         devopsScreen;
+static HAScreen             haScreen;
+static ClaudeScreen         claudeScreen;
+static WifiSettingsScreen   wifiSettingsScreen;
+static SettingsScreen       settingsScreen;
+static DiagnosticsScreen    diagnosticsScreen;
+
+/* Dashboard data — parsed from bridge JSON */
+static DashboardData dashData;
 
 /* --- LVGL display flush callback --- */
 static void lvglFlush(lv_disp_drv_t* drv, const lv_area_t* area, lv_color_t* color_p) {
@@ -50,9 +84,44 @@ static void lvglTouchRead(lv_indev_drv_t* drv, lv_indev_data_t* data) {
     }
 }
 
+/* --- Data callback: bridge JSON → DashboardData → all screens --- */
+static void onBridgeData(JsonDocument& doc) {
+    DashboardParser::parse(doc, dashData);
+    dashData.last_updated_ms = millis();
+
+    /* Mark all sources that have data as updated */
+    if (dashData.google_calendar.status == SourceStatus::OK)
+        StalenessTracker::markUpdated(DataSource::GOOGLE_CALENDAR);
+    if (dashData.microsoft_calendar.status == SourceStatus::OK)
+        StalenessTracker::markUpdated(DataSource::MICROSOFT_CALENDAR);
+    if (dashData.weather.status == SourceStatus::OK)
+        StalenessTracker::markUpdated(DataSource::WEATHER);
+    if (dashData.unfocused_tasks.status == SourceStatus::OK)
+        StalenessTracker::markUpdated(DataSource::UNFOCUSED_TASKS);
+    if (dashData.monday_tasks.status == SourceStatus::OK)
+        StalenessTracker::markUpdated(DataSource::MONDAY_TASKS);
+    if (dashData.github.status == SourceStatus::OK)
+        StalenessTracker::markUpdated(DataSource::GITHUB);
+    if (dashData.home_assistant.status == SourceStatus::OK)
+        StalenessTracker::markUpdated(DataSource::HOME_ASSISTANT);
+    if (dashData.beads.status == SourceStatus::OK)
+        StalenessTracker::markUpdated(DataSource::BEADS);
+    if (dashData.claude.status == SourceStatus::OK)
+        StalenessTracker::markUpdated(DataSource::CLAUDE);
+
+    /* Update error state */
+    ErrorState::recordSuccess();
+    ErrorState::setCachedDataAvailable(true);
+
+    /* Push data to all screens */
+    ScreenManager::updateAll(dashData);
+
+    Serial.printf("DCC: data updated, heap=%lu\n", ESP.getFreeHeap());
+}
+
 void setup() {
     Serial.begin(115200);
-    Serial.println("DCC: starting...");
+    Serial.println("\n=== Desk Command Center ===");
 
     /* Init config store */
     ConfigStore::init();
@@ -70,7 +139,7 @@ void setup() {
     buf1 = (lv_color_t*)ps_malloc(SCREEN_WIDTH * BUF_LINES * sizeof(lv_color_t));
     buf2 = (lv_color_t*)ps_malloc(SCREEN_WIDTH * BUF_LINES * sizeof(lv_color_t));
     if (!buf1 || !buf2) {
-        Serial.println("ERROR: PSRAM buffer allocation failed");
+        Serial.println("FATAL: PSRAM buffer allocation failed");
         return;
     }
     lv_disp_draw_buf_init(&draw_buf, buf1, buf2, SCREEN_WIDTH * BUF_LINES);
@@ -92,39 +161,79 @@ void setup() {
     Serial.printf("DCC: LVGL ready (%dx%d, %lu KB PSRAM buffers)\n",
                   SCREEN_WIDTH, SCREEN_HEIGHT,
                   (SCREEN_WIDTH * BUF_LINES * sizeof(lv_color_t) * 2) / 1024);
-    Serial.printf("DCC: Free heap: %lu, PSRAM: %lu\n",
-                  ESP.getFreeHeap(), ESP.getFreePsram());
 
     /* Show splash screen immediately */
     splash.create(nullptr);
     lv_scr_load(splash.screen());
-    splash.updateStatus("Loading config...");
+    splash.updateStatus("Initializing...");
     lv_timer_handler();
 
     /* Init backlight */
     Backlight::init();
     Backlight::setBrightness(cfg.brightness);
 
-    /* Init WiFi */
+    /* Init subsystems */
     splash.updateStatus("Connecting to WiFi...");
     lv_timer_handler();
     WifiManager::init(cfg);
+    ErrorState::init();
+    ErrorState::setWifiConnected(WifiManager::state() == WifiState::CONNECTED);
 
-    /* Init NTP time sync */
     splash.updateStatus("Syncing time...");
     lv_timer_handler();
     NtpTime::init(cfg.timezone);
 
-    /* Init data service */
-    splash.updateStatus("Ready");
+    splash.updateStatus("Starting data service...");
     lv_timer_handler();
+    StalenessTracker::init();
     DataService::init(cfg.bridge_url, cfg.poll_interval_sec);
+    DataService::onData(onBridgeData);
+
+    /* Register all screens */
+    splash.updateStatus("Building UI...");
+    lv_timer_handler();
+    ScreenManager::init();
+    ScreenManager::registerScreen(ScreenId::HOME,        &homeScreen);
+    ScreenManager::registerScreen(ScreenId::CALENDAR,    &calendarScreen);
+    ScreenManager::registerScreen(ScreenId::TASKS,       &tasksScreen);
+    ScreenManager::registerScreen(ScreenId::WEATHER,     &weatherScreen);
+    ScreenManager::registerScreen(ScreenId::DEVOPS,      &devopsScreen);
+    ScreenManager::registerScreen(ScreenId::HA,          &haScreen);
+    ScreenManager::registerScreen(ScreenId::CLAUDE,      &claudeScreen);
+    ScreenManager::registerScreen(ScreenId::SETTINGS,    &settingsScreen);
+    ScreenManager::registerScreen(ScreenId::DIAGNOSTICS, &diagnosticsScreen);
+
+    /* WiFi settings screen is a sub-screen accessed from Settings,
+       but we still need it registered if we add a nav path later.
+       For now, we use the SETTINGS slot for the combined settings screen. */
+
+    /* Create persistent UI layers (status bar + nav bar + OSK) */
+    StatusBar::create();
+    NavBar::create();
+    OSK::init();
+
+    /* Transition from splash to home */
+    splash.updateStatus("Ready!");
+    lv_timer_handler();
+    delay(500);
+    ScreenManager::show(ScreenId::HOME, LV_SCR_LOAD_ANIM_FADE_ON, 400, false);
+
+    Serial.printf("DCC: boot complete, heap=%lu, PSRAM=%lu\n",
+                  ESP.getFreeHeap(), ESP.getFreePsram());
 }
 
 void loop() {
     lv_timer_handler();
     WifiManager::check();
     NtpTime::check();
-    DataService::poll();
+
+    /* Update error state from WiFi */
+    ErrorState::setWifiConnected(WifiManager::state() == WifiState::CONNECTED);
+
+    /* Poll bridge data (respects interval + backoff) */
+    if (ErrorState::shouldRetry() || ErrorState::state() == ConnState::CONNECTED) {
+        DataService::poll();
+    }
+
     delay(5);
 }

--- a/firmware/src/ui/screens/claude_screen.cpp
+++ b/firmware/src/ui/screens/claude_screen.cpp
@@ -1,0 +1,158 @@
+/**
+ * Claude Activity Screen — Implementation
+ * Content area: y=30..430.
+ * Agent status card + Beads task summary.
+ */
+
+#include "ui/screens/claude_screen.h"
+#include <cstring>
+
+static const lv_color_t BG_COLOR       = lv_color_hex(0x0f0f23);
+static const lv_color_t CARD_BG        = lv_color_hex(0x1a1a2e);
+static const lv_color_t TEXT_PRIMARY   = lv_color_hex(0xE0E0FF);
+static const lv_color_t TEXT_SECONDARY = lv_color_hex(0x8888AA);
+static const lv_color_t ACCENT         = lv_color_hex(0x6C63FF);
+static const lv_color_t STATUS_ACTIVE  = lv_color_hex(0x44BB44);
+static const lv_color_t STATUS_IDLE    = lv_color_hex(0xFFAA00);
+static const lv_color_t STATUS_OFF     = lv_color_hex(0xFF4444);
+
+static constexpr int16_t CONTENT_Y = 30;
+static constexpr int16_t PAD       = 10;
+
+static lv_obj_t* makeCard(lv_obj_t* parent, int16_t x, int16_t y,
+                           int16_t w, int16_t h) {
+    lv_obj_t* card = lv_obj_create(parent);
+    lv_obj_set_pos(card, x, y);
+    lv_obj_set_size(card, w, h);
+    lv_obj_set_style_bg_color(card, CARD_BG, 0);
+    lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(card, 12, 0);
+    lv_obj_set_style_border_width(card, 0, 0);
+    lv_obj_set_style_pad_all(card, 16, 0);
+    lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
+    return card;
+}
+
+void ClaudeScreen::create(lv_obj_t* parent) {
+    _screen = lv_obj_create(nullptr);
+    lv_obj_set_style_bg_color(_screen, BG_COLOR, 0);
+    lv_obj_set_style_bg_opa(_screen, LV_OPA_COVER, 0);
+
+    /* Header */
+    lv_obj_t* header = lv_label_create(_screen);
+    lv_obj_set_style_text_font(header, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(header, TEXT_SECONDARY, 0);
+    lv_obj_set_pos(header, PAD + 4, CONTENT_Y + 8);
+    lv_label_set_text(header, LV_SYMBOL_CHARGE " Claude Agent");
+
+    /* === Agent Status Card === */
+    lv_obj_t* agentCard = makeCard(_screen, PAD, CONTENT_Y + 35, 780, 160);
+
+    /* Status dot */
+    _statusDot = lv_obj_create(agentCard);
+    lv_obj_set_size(_statusDot, 16, 16);
+    lv_obj_align(_statusDot, LV_ALIGN_TOP_LEFT, 0, 4);
+    lv_obj_set_style_bg_color(_statusDot, STATUS_OFF, 0);
+    lv_obj_set_style_bg_opa(_statusDot, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(_statusDot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_border_width(_statusDot, 0, 0);
+
+    /* Status text */
+    _lblStatus = lv_label_create(agentCard);
+    lv_obj_set_style_text_font(_lblStatus, &lv_font_montserrat_20, 0);
+    lv_obj_set_style_text_color(_lblStatus, TEXT_PRIMARY, 0);
+    lv_obj_align(_lblStatus, LV_ALIGN_TOP_LEFT, 26, 0);
+    lv_label_set_text(_lblStatus, "Offline");
+
+    /* Current task */
+    lv_obj_t* taskHdr = lv_label_create(agentCard);
+    lv_label_set_text(taskHdr, "Current Task:");
+    lv_obj_set_style_text_font(taskHdr, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(taskHdr, TEXT_SECONDARY, 0);
+    lv_obj_align(taskHdr, LV_ALIGN_TOP_LEFT, 0, 40);
+
+    _lblTask = lv_label_create(agentCard);
+    lv_obj_set_style_text_font(_lblTask, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(_lblTask, TEXT_PRIMARY, 0);
+    lv_obj_align(_lblTask, LV_ALIGN_TOP_LEFT, 0, 62);
+    lv_obj_set_width(_lblTask, 740);
+    lv_label_set_long_mode(_lblTask, LV_LABEL_LONG_WRAP);
+    lv_label_set_text(_lblTask, "No active task");
+
+    /* === Beads Summary Card === */
+    lv_obj_t* beadsCard = makeCard(_screen, PAD, CONTENT_Y + 210, 780, 120);
+
+    lv_obj_t* beadsHdr = lv_label_create(beadsCard);
+    lv_label_set_text(beadsHdr, "Beads Task Tracker");
+    lv_obj_set_style_text_font(beadsHdr, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(beadsHdr, TEXT_SECONDARY, 0);
+    lv_obj_align(beadsHdr, LV_ALIGN_TOP_LEFT, 0, 0);
+
+    _lblBeadsOpen = lv_label_create(beadsCard);
+    lv_obj_set_style_text_font(_lblBeadsOpen, &lv_font_montserrat_20, 0);
+    lv_obj_set_style_text_color(_lblBeadsOpen, TEXT_PRIMARY, 0);
+    lv_obj_align(_lblBeadsOpen, LV_ALIGN_TOP_LEFT, 0, 30);
+    lv_label_set_text(_lblBeadsOpen, "Open: --");
+
+    _lblBeadsIP = lv_label_create(beadsCard);
+    lv_obj_set_style_text_font(_lblBeadsIP, &lv_font_montserrat_20, 0);
+    lv_obj_set_style_text_color(_lblBeadsIP, TEXT_PRIMARY, 0);
+    lv_obj_align(_lblBeadsIP, LV_ALIGN_TOP_LEFT, 250, 30);
+    lv_label_set_text(_lblBeadsIP, "In Progress: --");
+
+    _lblBeadsBlk = lv_label_create(beadsCard);
+    lv_obj_set_style_text_font(_lblBeadsBlk, &lv_font_montserrat_20, 0);
+    lv_obj_set_style_text_color(_lblBeadsBlk, STATUS_OFF, 0);
+    lv_obj_align(_lblBeadsBlk, LV_ALIGN_TOP_LEFT, 540, 30);
+    lv_label_set_text(_lblBeadsBlk, "Blocked: --");
+
+    Serial.println("CLAUDE: screen created");
+}
+
+void ClaudeScreen::update(const DashboardData& data) {
+    /* Agent status */
+    if (data.claude.status == SourceStatus::OK) {
+        const ClaudeData& c = data.claude.data;
+
+        lv_color_t dotColor = STATUS_OFF;
+        if (strcmp(c.status, "active") == 0)      dotColor = STATUS_ACTIVE;
+        else if (strcmp(c.status, "idle") == 0)    dotColor = STATUS_IDLE;
+
+        lv_obj_set_style_bg_color(_statusDot, dotColor, 0);
+
+        char statusBuf[32];
+        /* Capitalize first letter */
+        snprintf(statusBuf, sizeof(statusBuf), "%s", c.status);
+        if (statusBuf[0] >= 'a' && statusBuf[0] <= 'z') statusBuf[0] -= 32;
+        lv_label_set_text(_lblStatus, statusBuf);
+
+        if (c.current_task[0] != '\0') {
+            lv_label_set_text(_lblTask, c.current_task);
+        } else {
+            lv_label_set_text(_lblTask, "No active task");
+        }
+    } else {
+        lv_obj_set_style_bg_color(_statusDot, STATUS_OFF, 0);
+        lv_label_set_text(_lblStatus, "Offline");
+        lv_label_set_text(_lblTask, "No data from bridge");
+    }
+
+    /* Beads summary */
+    if (data.beads.status == SourceStatus::OK) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "Open: %d", data.beads.data.open_count);
+        lv_label_set_text(_lblBeadsOpen, buf);
+        snprintf(buf, sizeof(buf), "In Progress: %d",
+                 data.beads.data.in_progress_count);
+        lv_label_set_text(_lblBeadsIP, buf);
+        snprintf(buf, sizeof(buf), "Blocked: %d",
+                 data.beads.data.blocked_count);
+        lv_label_set_text(_lblBeadsBlk, buf);
+        lv_obj_set_style_text_color(_lblBeadsBlk,
+            data.beads.data.blocked_count > 0 ? STATUS_OFF : TEXT_PRIMARY, 0);
+    } else {
+        lv_label_set_text(_lblBeadsOpen, "Open: --");
+        lv_label_set_text(_lblBeadsIP, "In Progress: --");
+        lv_label_set_text(_lblBeadsBlk, "Blocked: --");
+    }
+}

--- a/firmware/src/ui/screens/diagnostics_screen.cpp
+++ b/firmware/src/ui/screens/diagnostics_screen.cpp
@@ -1,0 +1,182 @@
+/**
+ * Diagnostics Screen — Implementation
+ * Content area: y=30..430. Auto-refresh every 2 seconds.
+ */
+
+#include "ui/screens/diagnostics_screen.h"
+#include "wifi_manager.h"
+#include "data_service.h"
+
+static const lv_color_t BG_COLOR       = lv_color_hex(0x0f0f23);
+static const lv_color_t CARD_BG        = lv_color_hex(0x1a1a2e);
+static const lv_color_t TEXT_PRIMARY   = lv_color_hex(0xE0E0FF);
+static const lv_color_t TEXT_SECONDARY = lv_color_hex(0x8888AA);
+static const lv_color_t ACCENT         = lv_color_hex(0x6C63FF);
+static const lv_color_t GOOD           = lv_color_hex(0x44BB44);
+static const lv_color_t WARN           = lv_color_hex(0xFFAA00);
+static const lv_color_t BAD            = lv_color_hex(0xFF4444);
+
+static constexpr int16_t CONTENT_Y = 30;
+static constexpr int16_t PAD       = 10;
+
+#define FW_VERSION "0.2.0-dev"
+
+static lv_obj_t* makeCard(lv_obj_t* parent, int16_t x, int16_t y,
+                           int16_t w, int16_t h) {
+    lv_obj_t* card = lv_obj_create(parent);
+    lv_obj_set_pos(card, x, y);
+    lv_obj_set_size(card, w, h);
+    lv_obj_set_style_bg_color(card, CARD_BG, 0);
+    lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(card, 12, 0);
+    lv_obj_set_style_border_width(card, 0, 0);
+    lv_obj_set_style_pad_all(card, 12, 0);
+    lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
+    return card;
+}
+
+static lv_obj_t* addRow(lv_obj_t* parent, const char* label, int16_t y) {
+    lv_obj_t* lbl = lv_label_create(parent);
+    lv_obj_set_style_text_font(lbl, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(lbl, TEXT_SECONDARY, 0);
+    lv_obj_align(lbl, LV_ALIGN_TOP_LEFT, 0, y);
+    lv_label_set_text(lbl, label);
+
+    lv_obj_t* val = lv_label_create(parent);
+    lv_obj_set_style_text_font(val, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(val, TEXT_PRIMARY, 0);
+    lv_obj_align(val, LV_ALIGN_TOP_LEFT, 140, y);
+    lv_label_set_text(val, "--");
+    return val;
+}
+
+void DiagnosticsScreen::onRefreshTimer(lv_timer_t* timer) {
+    auto* self = (DiagnosticsScreen*)timer->user_data;
+    self->refreshSystemInfo();
+}
+
+void DiagnosticsScreen::create(lv_obj_t* parent) {
+    _screen = lv_obj_create(nullptr);
+    lv_obj_set_style_bg_color(_screen, BG_COLOR, 0);
+    lv_obj_set_style_bg_opa(_screen, LV_OPA_COVER, 0);
+
+    /* Header */
+    lv_obj_t* header = lv_label_create(_screen);
+    lv_obj_set_style_text_font(header, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(header, TEXT_SECONDARY, 0);
+    lv_obj_set_pos(header, PAD + 4, CONTENT_Y + 8);
+    lv_label_set_text(header, LV_SYMBOL_SETTINGS " Diagnostics");
+
+    /* === System Card (left) === */
+    lv_obj_t* sysCard = makeCard(_screen, PAD, CONTENT_Y + 35, 380, 180);
+
+    lv_obj_t* sysHdr = lv_label_create(sysCard);
+    lv_label_set_text(sysHdr, "System");
+    lv_obj_set_style_text_font(sysHdr, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(sysHdr, TEXT_PRIMARY, 0);
+    lv_obj_align(sysHdr, LV_ALIGN_TOP_LEFT, 0, 0);
+
+    _lblVersion = addRow(sysCard, "FW Version:", 28);
+    _lblHeap    = addRow(sysCard, "Free Heap:", 52);
+    _lblPSRAM   = addRow(sysCard, "Free PSRAM:", 76);
+    _lblUptime  = addRow(sysCard, "Uptime:", 100);
+
+    /* === WiFi Card (right) === */
+    lv_obj_t* wifiCard = makeCard(_screen, 400, CONTENT_Y + 35, 390, 180);
+
+    lv_obj_t* wifiHdr = lv_label_create(wifiCard);
+    lv_label_set_text(wifiHdr, "WiFi");
+    lv_obj_set_style_text_font(wifiHdr, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(wifiHdr, TEXT_PRIMARY, 0);
+    lv_obj_align(wifiHdr, LV_ALIGN_TOP_LEFT, 0, 0);
+
+    _lblWifiSSID = addRow(wifiCard, "SSID:", 28);
+    _lblWifiIP   = addRow(wifiCard, "IP:", 52);
+    _lblWifiRSSI = addRow(wifiCard, "RSSI:", 76);
+
+    /* === Data Service Card (bottom) === */
+    lv_obj_t* dataCard = makeCard(_screen, PAD, CONTENT_Y + 230, 780, 120);
+
+    lv_obj_t* dataHdr = lv_label_create(dataCard);
+    lv_label_set_text(dataHdr, "Bridge Data Service");
+    lv_obj_set_style_text_font(dataHdr, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(dataHdr, TEXT_PRIMARY, 0);
+    lv_obj_align(dataHdr, LV_ALIGN_TOP_LEFT, 0, 0);
+
+    _lblLastFetch = addRow(dataCard, "Last Fetch:", 28);
+    _lblFetchErr  = addRow(dataCard, "Last Error:", 52);
+
+    /* Auto-refresh timer (2s, paused until shown) */
+    _refreshTimer = lv_timer_create(onRefreshTimer, 2000, this);
+    lv_timer_pause(_refreshTimer);
+
+    Serial.println("DIAG: screen created");
+}
+
+void DiagnosticsScreen::refreshSystemInfo() {
+    /* Version */
+    lv_label_set_text(_lblVersion, FW_VERSION);
+
+    /* Heap */
+    char buf[64];
+    uint32_t freeHeap = ESP.getFreeHeap();
+    snprintf(buf, sizeof(buf), "%lu KB", freeHeap / 1024);
+    lv_label_set_text(_lblHeap, buf);
+    lv_obj_set_style_text_color(_lblHeap,
+        freeHeap < 30000 ? BAD : (freeHeap < 60000 ? WARN : GOOD), 0);
+
+    /* PSRAM */
+    uint32_t freePSRAM = ESP.getFreePsram();
+    snprintf(buf, sizeof(buf), "%lu KB", freePSRAM / 1024);
+    lv_label_set_text(_lblPSRAM, buf);
+
+    /* Uptime */
+    uint32_t sec = millis() / 1000;
+    uint32_t hr = sec / 3600;
+    uint32_t mn = (sec % 3600) / 60;
+    uint32_t sc = sec % 60;
+    snprintf(buf, sizeof(buf), "%luh %02lum %02lus", hr, mn, sc);
+    lv_label_set_text(_lblUptime, buf);
+
+    /* WiFi */
+    if (WifiManager::state() == WifiState::CONNECTED) {
+        lv_label_set_text(_lblWifiSSID, WifiManager::ssid().c_str());
+        lv_label_set_text(_lblWifiIP, WifiManager::ip().c_str());
+        snprintf(buf, sizeof(buf), "%d dBm", WifiManager::rssi());
+        lv_label_set_text(_lblWifiRSSI, buf);
+        lv_obj_set_style_text_color(_lblWifiRSSI,
+            WifiManager::rssi() > -60 ? GOOD : (WifiManager::rssi() > -75 ? WARN : BAD), 0);
+    } else {
+        lv_label_set_text(_lblWifiSSID, "Disconnected");
+        lv_label_set_text(_lblWifiIP, "--");
+        lv_label_set_text(_lblWifiRSSI, "--");
+    }
+
+    /* Data service */
+    uint32_t lastMs = DataService::lastFetchMs();
+    if (lastMs > 0) {
+        uint32_t ago = (millis() - lastMs) / 1000;
+        snprintf(buf, sizeof(buf), "%lus ago", ago);
+        lv_label_set_text(_lblLastFetch, buf);
+    } else {
+        lv_label_set_text(_lblLastFetch, "Never");
+    }
+
+    String err = DataService::lastError();
+    if (err.length() > 0) {
+        lv_label_set_text(_lblFetchErr, err.c_str());
+        lv_obj_set_style_text_color(_lblFetchErr, BAD, 0);
+    } else {
+        lv_label_set_text(_lblFetchErr, "None");
+        lv_obj_set_style_text_color(_lblFetchErr, GOOD, 0);
+    }
+}
+
+void DiagnosticsScreen::update(const DashboardData& data) {
+    /* Diagnostics doesn't use dashboard data directly */
+}
+
+void DiagnosticsScreen::onShow() {
+    refreshSystemInfo();
+    if (_refreshTimer) lv_timer_resume(_refreshTimer);
+}


### PR DESCRIPTION
## Summary
This is the integration commit that makes the firmware fully navigable and flashable.

### New screens
- **Claude Activity** — agent status dot (active/idle/offline), current task, Beads counts
- **Diagnostics** — FW version, free heap/PSRAM, WiFi RSSI/IP, uptime, data service status (2s auto-refresh)

### Main.cpp wiring
- Instantiate all 9 screen classes (static, create-once lifecycle)
- Register with `ScreenManager` for nav bar routing
- Create `StatusBar` + `NavBar` + `OSK` on `lv_layer_top()`
- Connect `DataService::onData()` → `DashboardParser::parse()` → `ScreenManager::updateAll()`
- Integrate `StalenessTracker::markUpdated()` per source on successful fetch
- Integrate `ErrorState` into WiFi check and data polling loop
- Boot: Splash → subsystem init → screen registration → fade to Home

### Build stats
- RAM: 42.5% (139KB / 320KB)
- Flash: 22.8% (1.5MB / 6.5MB)

## Test plan
- [ ] Flash to CrowPanel — verify boot splash → home transition
- [ ] Tap nav bar icons: Home, Calendar, Tasks, Weather
- [ ] Tap "More" → DevOps, Claude, Home Asst, Settings, Diagnostics
- [ ] Verify Diagnostics shows heap/PSRAM/uptime updating
- [ ] Connect bridge and verify data flows to all screens
- [ ] Verify status bar shows time, WiFi, sync indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)