### PR TITLE
feat(#2dh): task priority dots, deferred count, fixed sort

### DIFF
--- a/bridge/adapters/unfocused_tasks.py
+++ b/bridge/adapters/unfocused_tasks.py
@@ -14,18 +14,32 @@ logger = logging.getLogger(__name__)
 # Map Unfocused priority strings to firmware uint8_t values.
 # Firmware: 0=none, 1=high, 2=medium, 3=low
 _PRIORITY_MAP = {
+    # Pn prefix format (e.g. "P1 - High")
     "P0": 1,  # Critical → high
     "P1": 1,  # High
     "P2": 2,  # Medium
     "P3": 3,  # Low
+    # Plain word format (e.g. "High", "Medium", "Low")
+    "High": 1,
+    "Medium": 2,
+    "Low": 3,
 }
+
+# Statuses considered "active" (shown in task list)
+_ACTIVE_STATUSES = {"not_started", "in_progress"}
+# Statuses considered "deferred" (counted but not shown)
+_DEFERRED_STATUSES = {"on_hold"}
 
 
 def _parse_priority(priority_str: str | None) -> int:
-    """Extract priority level from strings like 'P2 - Medium'."""
+    """Map priority from 'P2 - Medium', 'High', 'Medium', etc."""
     if not priority_str:
         return 0
-    prefix = priority_str[:2]  # "P0", "P1", etc.
+    # Try exact match first (handles "High", "Medium", "Low")
+    if priority_str in _PRIORITY_MAP:
+        return _PRIORITY_MAP[priority_str]
+    # Try Pn prefix (handles "P2 - Medium" format)
+    prefix = priority_str[:2]
     return _PRIORITY_MAP.get(prefix, 0)
 
 
@@ -56,7 +70,6 @@ class UnfocusedTasksAdapter(BaseAdapter):
         )
         self.api_url = uf_cfg.get("api_url", "https://getunfocused.app")
         self.api_key = uf_cfg.get("api_key", "")
-        self.statuses = uf_cfg.get("statuses", ["not_started", "in_progress"])
         self.limit = uf_cfg.get("limit", 50)
 
     async def poll(self) -> dict[str, Any]:
@@ -64,10 +77,7 @@ class UnfocusedTasksAdapter(BaseAdapter):
             raise ValueError("unfocused_tasks.api_key not configured")
 
         url = f"{self.api_url.rstrip('/')}/api/tasks"
-        params = {
-            "status": ",".join(self.statuses),
-            "limit": self.limit,
-        }
+        params = {"limit": self.limit}
         headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Accept": "application/json",
@@ -80,19 +90,26 @@ class UnfocusedTasksAdapter(BaseAdapter):
 
     def parse(self, raw: dict[str, Any]) -> dict[str, Any]:
         raw_tasks = raw.get("tasks", [])
-        meta = raw.get("meta", {})
 
         tasks = []
+        deferred_count = 0
         for t in raw_tasks:
+            status = t.get("status", "")
+            if status in _DEFERRED_STATUSES:
+                deferred_count += 1
+                continue
+            if status not in _ACTIVE_STATUSES:
+                continue
             tasks.append({
                 "title": t.get("title", ""),
                 "due_date": t.get("due_date", ""),
                 "priority": _parse_priority(t.get("priority")),
                 "source": "unfocused",
-                "completed": t.get("status") == "completed",
+                "completed": status == "completed",
             })
 
         return {
             "tasks": tasks,
-            "total": meta.get("total", len(tasks)),
+            "total": len(tasks),
+            "deferred_count": deferred_count,
         }

--- a/firmware/include/dashboard_data.h
+++ b/firmware/include/dashboard_data.h
@@ -107,6 +107,7 @@ struct DashboardData {
 
     SourceBlock<TaskItem[MAX_TASKS]> unfocused_tasks;
     uint8_t unfocused_tasks_count;
+    uint8_t unfocused_deferred_count;
 
     SourceBlock<TaskItem[MAX_TASKS]> monday_tasks;
     uint8_t monday_tasks_count;

--- a/firmware/include/ui/home_screen.h
+++ b/firmware/include/ui/home_screen.h
@@ -34,7 +34,9 @@ private:
 
     /* Tasks summary card */
     lv_obj_t* _cardTasks    = nullptr;
+    lv_obj_t* _taskDots[5]  = {};      // Priority color dot
     lv_obj_t* _lblTaskItems[5] = {};
+    lv_obj_t* _lblDeferred  = nullptr; // "N deferred" badge
     uint8_t   _taskItemCount = 0;
 
     void createClock(lv_obj_t* parent);

--- a/firmware/src/dashboard_data.cpp
+++ b/firmware/src/dashboard_data.cpp
@@ -148,15 +148,17 @@ void DashboardParser::parse(const JsonDocument& doc, DashboardData& out) {
         out.weather.status = SourceStatus::MISSING;
     }
 
-    /* Unfocused Tasks — data.tasks is the array */
+    /* Unfocused Tasks — data.tasks is the array, data.deferred_count for on_hold */
     JsonObjectConst ut = sources["unfocused_tasks"];
     if (!ut.isNull()) {
         parseSourceMeta(ut, out.unfocused_tasks);
         JsonObjectConst utd = ut["data"];
         parseTaskItems(utd["tasks"], out.unfocused_tasks.data,
                       out.unfocused_tasks_count, MAX_TASKS);
+        out.unfocused_deferred_count = utd["deferred_count"] | 0;
     } else {
         out.unfocused_tasks.status = SourceStatus::MISSING;
+        out.unfocused_deferred_count = 0;
     }
 
     /* Monday Tasks */

--- a/firmware/src/ui/home_screen.cpp
+++ b/firmware/src/ui/home_screen.cpp
@@ -17,6 +17,12 @@ static const lv_color_t TEXT_PRIMARY  = lv_color_hex(0xE0E0FF);
 static const lv_color_t TEXT_SECONDARY = lv_color_hex(0xB0B0D0);
 static const lv_color_t ACCENT       = lv_color_hex(0x6C63FF);
 
+/* Task priority dot colors */
+static const lv_color_t PRIO_HIGH    = lv_color_hex(0xFF4444);
+static const lv_color_t PRIO_MED     = lv_color_hex(0xFFAA00);
+static const lv_color_t PRIO_LOW     = lv_color_hex(0x44AA44);
+static const lv_color_t PRIO_NONE    = lv_color_hex(0x555577);
+
 static constexpr int16_t CONTENT_Y   = 30;
 static constexpr int16_t CONTENT_H   = 400;
 static constexpr int16_t PAD         = 10;
@@ -240,15 +246,49 @@ void HomeScreen::createTasksCard(lv_obj_t* parent) {
     lv_obj_align(header, LV_ALIGN_TOP_LEFT, 0, 0);
 
     for (uint8_t i = 0; i < 5; i++) {
+        int16_t rowY = 24 + i * 28;
+
+        /* Priority color dot — 8px circle */
+        _taskDots[i] = lv_obj_create(_cardTasks);
+        lv_obj_set_size(_taskDots[i], 8, 8);
+        lv_obj_set_style_radius(_taskDots[i], LV_RADIUS_CIRCLE, 0);
+        lv_obj_set_style_bg_opa(_taskDots[i], LV_OPA_COVER, 0);
+        lv_obj_set_style_bg_color(_taskDots[i], PRIO_NONE, 0);
+        lv_obj_set_style_border_width(_taskDots[i], 0, 0);
+        lv_obj_clear_flag(_taskDots[i], LV_OBJ_FLAG_SCROLLABLE);
+        lv_obj_align(_taskDots[i], LV_ALIGN_TOP_LEFT, 0, rowY + 6);
+        lv_obj_add_flag(_taskDots[i], LV_OBJ_FLAG_HIDDEN);
+
+        /* Task title label — shifted right to make room for dot */
         _lblTaskItems[i] = lv_label_create(_cardTasks);
         lv_obj_set_style_text_font(_lblTaskItems[i], &lv_font_montserrat_20, 0);
         lv_obj_set_style_text_color(_lblTaskItems[i], TEXT_PRIMARY, 0);
-        lv_obj_align(_lblTaskItems[i], LV_ALIGN_TOP_LEFT, 0, 24 + i * 28);
-        lv_obj_set_width(_lblTaskItems[i], 360);
+        lv_obj_align(_lblTaskItems[i], LV_ALIGN_TOP_LEFT, 14, rowY);
+        lv_obj_set_width(_lblTaskItems[i], 346);
         lv_label_set_long_mode(_lblTaskItems[i], LV_LABEL_LONG_DOT);
         lv_label_set_text(_lblTaskItems[i], "");
     }
+
+    /* Deferred count badge — bottom-right of card */
+    _lblDeferred = lv_label_create(_cardTasks);
+    lv_obj_set_style_text_font(_lblDeferred, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(_lblDeferred, TEXT_SECONDARY, 0);
+    lv_obj_align(_lblDeferred, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+    lv_label_set_text(_lblDeferred, "");
+
     _taskItemCount = 0;
+}
+
+/* Sort key: priority 1 (high) first, 2, 3, then 0 (none) last. */
+static uint8_t prioSortKey(uint8_t p) { return p == 0 ? 4 : p; }
+
+static lv_color_t prioColor(uint8_t p) {
+    switch (p) {
+        case 1:  return PRIO_HIGH;
+        case 2:  return PRIO_MED;
+        case 3:  return PRIO_LOW;
+        default: return PRIO_NONE;
+    }
 }
 
 void HomeScreen::updateTasks(const DashboardData& data) {
@@ -286,10 +326,11 @@ void HomeScreen::updateTasks(const DashboardData& data) {
         }
     }
 
-    /* Sort by priority (simple bubble) */
+    /* Sort by priority: high(1) → med(2) → low(3) → none(0) */
     for (uint8_t i = 0; i < count; i++) {
         for (uint8_t j = i + 1; j < count; j++) {
-            if (merged[j].priority < merged[i].priority) {
+            if (prioSortKey(merged[j].priority)
+                < prioSortKey(merged[i].priority)) {
                 MergedTask tmp = merged[i];
                 merged[i] = merged[j];
                 merged[j] = tmp;
@@ -300,21 +341,33 @@ void HomeScreen::updateTasks(const DashboardData& data) {
     uint8_t show = (count > 5) ? 5 : count;
     for (uint8_t i = 0; i < 5; i++) {
         if (i < show) {
-            char buf[128];
-            const char* prio = "";
-            if (merged[i].priority == 1) prio = "! ";
-            else if (merged[i].priority == 2) prio = "- ";
-            snprintf(buf, sizeof(buf), "%s[%s] %s",
-                     prio, merged[i].source, merged[i].title);
-            lv_label_set_text(_lblTaskItems[i], buf);
+            /* Color dot */
+            lv_obj_set_style_bg_color(_taskDots[i], prioColor(merged[i].priority), 0);
+            lv_obj_clear_flag(_taskDots[i], LV_OBJ_FLAG_HIDDEN);
+
+            /* Task text — no more text-based priority prefix */
+            lv_label_set_text(_lblTaskItems[i], merged[i].title);
+            lv_obj_set_style_text_color(_lblTaskItems[i], TEXT_PRIMARY, 0);
         } else {
+            lv_obj_add_flag(_taskDots[i], LV_OBJ_FLAG_HIDDEN);
             lv_label_set_text(_lblTaskItems[i], "");
         }
     }
 
     if (count == 0) {
+        lv_obj_add_flag(_taskDots[0], LV_OBJ_FLAG_HIDDEN);
         lv_label_set_text(_lblTaskItems[0], "No task sources connected");
         lv_obj_set_style_text_color(_lblTaskItems[0], TEXT_SECONDARY, 0);
+    }
+
+    /* Deferred count badge */
+    uint8_t deferred = data.unfocused_deferred_count;
+    if (deferred > 0) {
+        char defBuf[24];
+        snprintf(defBuf, sizeof(defBuf), "%d deferred", deferred);
+        lv_label_set_text(_lblDeferred, defBuf);
+    } else {
+        lv_label_set_text(_lblDeferred, "");
     }
 }
 


### PR DESCRIPTION
## Summary
- **Bridge**: Fixed `_parse_priority()` to handle plain `"High"`/`"Medium"`/`"Low"` strings from the Unfocused API (was only matching `"P0"`/`"P1"` prefixes, causing all priorities to be 0). Removed status filter from API call; active vs deferred tasks now separated in `parse()`, returning `deferred_count` for on_hold items.
- **Firmware**: Replaced text-based priority prefixes (`"! "`, `"- "`) with color-coded 8px circle dots (red=high, orange=medium, green=low, gray=none). Fixed sort order so priority 0 (none) sorts last. Added `"N deferred"` badge at bottom-right of tasks card.

## Test plan
- [x] Firmware builds cleanly (RAM 78.8%, Flash 24.9%)
- [x] Flashed to CrowPanel via COM3
- [x] Bridge deployed to Pi, adapter returns correct priorities + deferred_count
- [ ] Visually verify color dots render on home screen task card
- [ ] Verify deferred count badge appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)