### PR TITLE
fix(#28o): add auto-saved indicator to Display settings card

### DIFF
--- a/firmware/src/ui/screens/settings_screen.cpp
+++ b/firmware/src/ui/screens/settings_screen.cpp
@@ -94,6 +94,7 @@ void SettingsScreen::onBrightnessChanged(lv_event_t* e) {
 void SettingsScreen::onBrightnessRelease(lv_event_t* e) {
     auto* self = (SettingsScreen*)lv_event_get_user_data(e);
     ConfigStore::save(self->_cfg);
+    lv_label_set_text(self->_lblStatus, "Brightness saved");
 }
 
 void SettingsScreen::on24hToggle(lv_event_t* e) {
@@ -214,6 +215,12 @@ void SettingsScreen::create(lv_obj_t* parent) {
     lv_obj_set_style_text_font(dispHdr, &lv_font_montserrat_16, 0);
     lv_obj_set_style_text_color(dispHdr, TEXT_PRIMARY, 0);
     lv_obj_align(dispHdr, LV_ALIGN_TOP_LEFT, 0, 0);
+
+    lv_obj_t* dispHint = lv_label_create(dispCard);
+    lv_label_set_text(dispHint, "(auto-saved)");
+    lv_obj_set_style_text_font(dispHint, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(dispHint, TEXT_SECONDARY, 0);
+    lv_obj_align_to(dispHint, dispHdr, LV_ALIGN_OUT_RIGHT_BOTTOM, 8, 0);
 
     /* Brightness slider */
     lv_obj_t* lblBright = lv_label_create(dispCard);


### PR DESCRIPTION
## Summary
- Added **(auto-saved)** subtitle next to the "Display" card header to distinguish it from cards with explicit Save buttons
- Added **"Brightness saved"** status text on slider release for consistent feedback (24h toggle already showed "Clock format saved")

## Test plan
- [x] Firmware compiles cleanly
- [x] Flashed to CrowPanel
- [ ] Verify "(auto-saved)" label appears next to "Display" header
- [ ] Verify "Brightness saved" appears in status bar when adjusting brightness slider

🤖 Generated with [Claude Code](https://claude.com/claude-code)