### PR TITLE
feat(#140): domain-specific HA widget cards

### DIFF
--- a/firmware/include/dashboard_data.h
+++ b/firmware/include/dashboard_data.h
@@ -75,6 +75,14 @@ struct HAEntity {
     char friendly_name[64];
     char state[32];
     char domain[16];
+
+    /* Domain-specific extras (union keeps memory compact) */
+    union {
+        struct { float current_temp; float target_temp;
+                 char hvac_action[16]; char preset_mode[16]; } climate;
+        struct { char unit[16]; char device_class[16]; } sensor;
+        struct { char media_title[48]; char app_name[24]; } media;
+    } extra;
 };
 
 struct GitHubData {

--- a/firmware/include/ui/screens/ha_screen.h
+++ b/firmware/include/ui/screens/ha_screen.h
@@ -1,6 +1,6 @@
 /**
- * Home Assistant Screen — Entity groups by domain.
- * Dynamic domain grouping from bridge entity data.
+ * Home Assistant Screen — Domain-specific widget cards.
+ * Climate thermostat, sensor values, light/switch toggles, media cards.
  */
 
 #pragma once
@@ -20,5 +20,11 @@ private:
     void rebuildEntityList(const HAData& ha);
     void addDomainGroup(const char* domain, const HAEntity* entities,
                         const uint8_t* indices, uint8_t count);
-    void addEntityRow(lv_obj_t* parent, const HAEntity& entity);
+
+    /* Domain-specific card renderers */
+    void addClimateCard(lv_obj_t* parent, const HAEntity& entity);
+    void addSensorRow(lv_obj_t* parent, const HAEntity& entity);
+    void addLightSwitchRow(lv_obj_t* parent, const HAEntity& entity);
+    void addMediaCard(lv_obj_t* parent, const HAEntity& entity);
+    void addGenericRow(lv_obj_t* parent, const HAEntity& entity);
 };

--- a/firmware/src/dashboard_data.cpp
+++ b/firmware/src/dashboard_data.cpp
@@ -225,10 +225,26 @@ void DashboardParser::parse(const JsonDocument& doc, DashboardData& out) {
                 for (JsonObjectConst e : entities) {
                     if (out.home_assistant.data.entity_count >= MAX_HA_ENTITIES) break;
                     HAEntity& ent = out.home_assistant.data.entities[out.home_assistant.data.entity_count];
+                    memset(&ent, 0, sizeof(ent));
                     copyStr(ent.entity_id, sizeof(ent.entity_id), e["entity_id"]);
                     copyStr(ent.friendly_name, sizeof(ent.friendly_name), e["friendly_name"]);
                     copyStr(ent.state, sizeof(ent.state), e["state"]);
                     copyStr(ent.domain, sizeof(ent.domain), domainName);
+
+                    /* Domain-specific attributes */
+                    if (strcmp(domainName, "climate") == 0) {
+                        ent.extra.climate.current_temp = e["current_temp"] | 0.0f;
+                        ent.extra.climate.target_temp  = e["target_temp"]  | 0.0f;
+                        copyStr(ent.extra.climate.hvac_action, sizeof(ent.extra.climate.hvac_action), e["hvac_action"]);
+                        copyStr(ent.extra.climate.preset_mode, sizeof(ent.extra.climate.preset_mode), e["preset_mode"]);
+                    } else if (strcmp(domainName, "sensor") == 0 || strcmp(domainName, "binary_sensor") == 0) {
+                        copyStr(ent.extra.sensor.unit, sizeof(ent.extra.sensor.unit), e["unit"]);
+                        copyStr(ent.extra.sensor.device_class, sizeof(ent.extra.sensor.device_class), e["device_class"]);
+                    } else if (strcmp(domainName, "media_player") == 0) {
+                        copyStr(ent.extra.media.media_title, sizeof(ent.extra.media.media_title), e["media_title"]);
+                        copyStr(ent.extra.media.app_name, sizeof(ent.extra.media.app_name), e["app_name"]);
+                    }
+
                     out.home_assistant.data.entity_count++;
                 }
             }

--- a/firmware/src/ui/screens/ha_screen.cpp
+++ b/firmware/src/ui/screens/ha_screen.cpp
@@ -1,7 +1,7 @@
 /**
  * Home Assistant Screen — Implementation
  * Content area: y=30..430.
- * Scrollable entity list grouped by domain with state display.
+ * Domain-specific widget cards: climate thermostat, sensors, lights, media.
  */
 
 #include "ui/screens/ha_screen.h"
@@ -13,38 +13,44 @@ static const lv_color_t CARD_BG        = lv_color_hex(0x1a1a2e);
 static const lv_color_t GROUP_BG       = lv_color_hex(0x252548);
 static const lv_color_t TEXT_PRIMARY   = lv_color_hex(0xE0E0FF);
 static const lv_color_t TEXT_SECONDARY = lv_color_hex(0xB0B0D0);
+static const lv_color_t TEXT_DIM       = lv_color_hex(0x888899);
 static const lv_color_t ACCENT         = lv_color_hex(0x6C63FF);
 static const lv_color_t STATE_ON       = lv_color_hex(0x44BB44);
 static const lv_color_t STATE_OFF      = lv_color_hex(0x666688);
+static const lv_color_t CLIMATE_HEAT   = lv_color_hex(0xFF6633);
+static const lv_color_t CLIMATE_COOL   = lv_color_hex(0x3399FF);
+static const lv_color_t CLIMATE_IDLE   = lv_color_hex(0x888899);
 
 static constexpr int16_t CONTENT_Y = 30;
 static constexpr int16_t PAD       = 10;
 
 /* Domain display names */
 static const char* domainLabel(const char* domain) {
-    if (strcmp(domain, "climate") == 0)     return "Climate";
-    if (strcmp(domain, "light") == 0)       return "Lights";
-    if (strcmp(domain, "lock") == 0)        return "Security";
+    if (strcmp(domain, "climate") == 0)       return "Climate";
+    if (strcmp(domain, "light") == 0)         return "Lights";
+    if (strcmp(domain, "lock") == 0)          return "Security";
     if (strcmp(domain, "binary_sensor") == 0) return "Sensors";
-    if (strcmp(domain, "sensor") == 0)      return "Sensors";
-    if (strcmp(domain, "switch") == 0)      return "Switches";
-    if (strcmp(domain, "cover") == 0)       return "Covers";
-    if (strcmp(domain, "fan") == 0)         return "Fans";
-    if (strcmp(domain, "media_player") == 0) return "Media";
+    if (strcmp(domain, "sensor") == 0)        return "Sensors";
+    if (strcmp(domain, "switch") == 0)        return "Switches";
+    if (strcmp(domain, "cover") == 0)         return "Covers";
+    if (strcmp(domain, "fan") == 0)           return "Fans";
+    if (strcmp(domain, "media_player") == 0)  return "Media";
+    if (strcmp(domain, "person") == 0)        return "People";
     return domain;
 }
 
 /* Domain icon (LVGL symbol) */
 static const char* domainIcon(const char* domain) {
-    if (strcmp(domain, "climate") == 0)     return LV_SYMBOL_CHARGE;
-    if (strcmp(domain, "light") == 0)       return LV_SYMBOL_EYE_OPEN;
-    if (strcmp(domain, "lock") == 0)        return LV_SYMBOL_CLOSE;
-    if (strcmp(domain, "sensor") == 0)      return LV_SYMBOL_GPS;
+    if (strcmp(domain, "climate") == 0)       return LV_SYMBOL_CHARGE;
+    if (strcmp(domain, "light") == 0)         return LV_SYMBOL_EYE_OPEN;
+    if (strcmp(domain, "lock") == 0)          return LV_SYMBOL_CLOSE;
+    if (strcmp(domain, "sensor") == 0)        return LV_SYMBOL_GPS;
     if (strcmp(domain, "binary_sensor") == 0) return LV_SYMBOL_GPS;
-    if (strcmp(domain, "switch") == 0)      return LV_SYMBOL_POWER;
-    if (strcmp(domain, "cover") == 0)       return LV_SYMBOL_UP;
-    if (strcmp(domain, "fan") == 0)         return LV_SYMBOL_REFRESH;
-    if (strcmp(domain, "media_player") == 0) return LV_SYMBOL_AUDIO;
+    if (strcmp(domain, "switch") == 0)        return LV_SYMBOL_POWER;
+    if (strcmp(domain, "cover") == 0)         return LV_SYMBOL_UP;
+    if (strcmp(domain, "fan") == 0)           return LV_SYMBOL_REFRESH;
+    if (strcmp(domain, "media_player") == 0)  return LV_SYMBOL_AUDIO;
+    if (strcmp(domain, "person") == 0)        return LV_SYMBOL_GPS;
     return LV_SYMBOL_HOME;
 }
 
@@ -58,7 +64,7 @@ void HAScreen::create(lv_obj_t* parent) {
     lv_obj_set_style_text_font(header, &lv_font_montserrat_16, 0);
     lv_obj_set_style_text_color(header, TEXT_SECONDARY, 0);
     lv_obj_set_pos(header, PAD + 4, CONTENT_Y + 8);
-    lv_label_set_text(header, LV_SYMBOL_HOME " Home Assistant");
+    lv_label_set_text(header, LV_SYMBOL_CHARGE " Home Assistant");
 
     /* Scrollable entity list */
     _entityList = lv_obj_create(_screen);
@@ -73,9 +79,228 @@ void HAScreen::create(lv_obj_t* parent) {
     LOG_INFO("HA: screen created");
 }
 
-void HAScreen::addEntityRow(lv_obj_t* parent, const HAEntity& entity) {
+/* ─── Climate Card: name, HVAC action, current/target temps ─── */
+void HAScreen::addClimateCard(lv_obj_t* parent, const HAEntity& entity) {
+    lv_obj_t* card = lv_obj_create(parent);
+    lv_obj_set_size(card, 720, 56);
+    lv_obj_set_style_bg_color(card, GROUP_BG, 0);
+    lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(card, 8, 0);
+    lv_obj_set_style_border_width(card, 0, 0);
+    lv_obj_set_style_pad_all(card, 8, 0);
+    lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
+
+    /* Name */
+    lv_obj_t* lblName = lv_label_create(card);
+    lv_obj_set_style_text_font(lblName, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(lblName, TEXT_PRIMARY, 0);
+    lv_obj_align(lblName, LV_ALIGN_TOP_LEFT, 0, 0);
+    lv_obj_set_width(lblName, 300);
+    lv_label_set_long_mode(lblName, LV_LABEL_LONG_DOT);
+    lv_label_set_text(lblName, entity.friendly_name[0]
+                                   ? entity.friendly_name
+                                   : entity.entity_id);
+
+    /* HVAC action indicator — colored dot */
+    bool heating = (strcmp(entity.extra.climate.hvac_action, "heating") == 0);
+    bool cooling = (strcmp(entity.extra.climate.hvac_action, "cooling") == 0);
+    lv_color_t actionColor = heating ? CLIMATE_HEAT
+                           : cooling ? CLIMATE_COOL
+                           : CLIMATE_IDLE;
+
+    lv_obj_t* dot = lv_obj_create(card);
+    lv_obj_set_size(dot, 8, 8);
+    lv_obj_set_style_bg_color(dot, actionColor, 0);
+    lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_border_width(dot, 0, 0);
+    lv_obj_align(dot, LV_ALIGN_TOP_LEFT, 310, 4);
+
+    /* HVAC action text */
+    lv_obj_t* lblAction = lv_label_create(card);
+    lv_obj_set_style_text_font(lblAction, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(lblAction, actionColor, 0);
+    lv_obj_align(lblAction, LV_ALIGN_TOP_LEFT, 324, 2);
+    const char* actionStr = entity.extra.climate.hvac_action;
+    if (actionStr[0]) {
+        char buf[16];
+        strncpy(buf, actionStr, sizeof(buf) - 1);
+        buf[sizeof(buf) - 1] = '\0';
+        if (buf[0] >= 'a' && buf[0] <= 'z') buf[0] -= 32;
+        lv_label_set_text(lblAction, buf);
+    } else {
+        lv_label_set_text(lblAction, entity.state);
+    }
+
+    /* Current temp — large */
+    lv_obj_t* lblCur = lv_label_create(card);
+    lv_obj_set_style_text_font(lblCur, &lv_font_montserrat_20, 0);
+    lv_obj_set_style_text_color(lblCur, TEXT_PRIMARY, 0);
+    lv_obj_align(lblCur, LV_ALIGN_TOP_RIGHT, 0, -2);
+    char tempBuf[16];
+    if (entity.extra.climate.current_temp > 0) {
+        snprintf(tempBuf, sizeof(tempBuf), "%.0f\xC2\xB0",
+                 entity.extra.climate.current_temp);
+    } else {
+        snprintf(tempBuf, sizeof(tempBuf), "%s", entity.state);
+    }
+    lv_label_set_text(lblCur, tempBuf);
+
+    /* Target temp — smaller, below current */
+    if (entity.extra.climate.target_temp > 0) {
+        lv_obj_t* lblTarget = lv_label_create(card);
+        lv_obj_set_style_text_font(lblTarget, &lv_font_montserrat_14, 0);
+        lv_obj_set_style_text_color(lblTarget, TEXT_DIM, 0);
+        lv_obj_align(lblTarget, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+        char tgtBuf[24];
+        snprintf(tgtBuf, sizeof(tgtBuf), "Target: %.0f\xC2\xB0",
+                 entity.extra.climate.target_temp);
+        lv_label_set_text(lblTarget, tgtBuf);
+    }
+
+    /* Preset mode — bottom left */
+    if (entity.extra.climate.preset_mode[0]) {
+        lv_obj_t* lblPreset = lv_label_create(card);
+        lv_obj_set_style_text_font(lblPreset, &lv_font_montserrat_14, 0);
+        lv_obj_set_style_text_color(lblPreset, TEXT_DIM, 0);
+        lv_obj_align(lblPreset, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+        lv_label_set_text(lblPreset, entity.extra.climate.preset_mode);
+    }
+}
+
+/* ─── Sensor Row: name + value with unit ─── */
+void HAScreen::addSensorRow(lv_obj_t* parent, const HAEntity& entity) {
+    lv_obj_t* row = lv_obj_create(parent);
+    lv_obj_set_size(row, 720, 28);
+    lv_obj_set_style_bg_opa(row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(row, 0, 0);
+    lv_obj_set_style_pad_all(row, 2, 0);
+    lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+
+    /* Entity name */
+    lv_obj_t* lblName = lv_label_create(row);
+    lv_obj_set_style_text_font(lblName, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(lblName, TEXT_PRIMARY, 0);
+    lv_obj_align(lblName, LV_ALIGN_LEFT_MID, 0, 0);
+    lv_obj_set_width(lblName, 500);
+    lv_label_set_long_mode(lblName, LV_LABEL_LONG_DOT);
+    lv_label_set_text(lblName, entity.friendly_name[0]
+                                   ? entity.friendly_name
+                                   : entity.entity_id);
+
+    /* Value + unit */
+    lv_obj_t* lblValue = lv_label_create(row);
+    lv_obj_set_style_text_font(lblValue, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(lblValue, ACCENT, 0);
+    lv_obj_align(lblValue, LV_ALIGN_RIGHT_MID, 0, 0);
+    char valBuf[48];
+    if (entity.extra.sensor.unit[0]) {
+        snprintf(valBuf, sizeof(valBuf), "%s %s",
+                 entity.state, entity.extra.sensor.unit);
+    } else {
+        snprintf(valBuf, sizeof(valBuf), "%s", entity.state);
+    }
+    lv_label_set_text(lblValue, valBuf);
+}
+
+/* ─── Light / Switch / Fan Row: colored dot + name + ON/OFF ─── */
+void HAScreen::addLightSwitchRow(lv_obj_t* parent, const HAEntity& entity) {
     lv_obj_t* row = lv_obj_create(parent);
     lv_obj_set_size(row, 720, 30);
+    lv_obj_set_style_bg_opa(row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(row, 0, 0);
+    lv_obj_set_style_pad_all(row, 2, 0);
+    lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+
+    /* On/off indicator dot */
+    bool isOn = (strcmp(entity.state, "on") == 0);
+    lv_obj_t* dot = lv_obj_create(row);
+    lv_obj_set_size(dot, 10, 10);
+    lv_obj_set_style_bg_color(dot, isOn ? STATE_ON : STATE_OFF, 0);
+    lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
+    lv_obj_set_style_border_width(dot, 0, 0);
+    lv_obj_align(dot, LV_ALIGN_LEFT_MID, 0, 0);
+
+    /* Entity name */
+    lv_obj_t* lblName = lv_label_create(row);
+    lv_obj_set_style_text_font(lblName, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(lblName, TEXT_PRIMARY, 0);
+    lv_obj_align(lblName, LV_ALIGN_LEFT_MID, 18, 0);
+    lv_obj_set_width(lblName, 480);
+    lv_label_set_long_mode(lblName, LV_LABEL_LONG_DOT);
+    lv_label_set_text(lblName, entity.friendly_name[0]
+                                   ? entity.friendly_name
+                                   : entity.entity_id);
+
+    /* State label */
+    lv_obj_t* lblState = lv_label_create(row);
+    lv_obj_set_style_text_font(lblState, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(lblState, isOn ? STATE_ON : STATE_OFF, 0);
+    lv_obj_align(lblState, LV_ALIGN_RIGHT_MID, 0, 0);
+    lv_label_set_text(lblState, isOn ? "ON" : "OFF");
+}
+
+/* ─── Media Card: name, state, now playing ─── */
+void HAScreen::addMediaCard(lv_obj_t* parent, const HAEntity& entity) {
+    lv_obj_t* card = lv_obj_create(parent);
+    lv_obj_set_size(card, 720, 46);
+    lv_obj_set_style_bg_color(card, GROUP_BG, 0);
+    lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(card, 8, 0);
+    lv_obj_set_style_border_width(card, 0, 0);
+    lv_obj_set_style_pad_all(card, 6, 0);
+    lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
+
+    bool isPlaying = (strcmp(entity.state, "playing") == 0);
+
+    /* Name */
+    lv_obj_t* lblName = lv_label_create(card);
+    lv_obj_set_style_text_font(lblName, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(lblName, TEXT_PRIMARY, 0);
+    lv_obj_align(lblName, LV_ALIGN_TOP_LEFT, 0, 0);
+    lv_obj_set_width(lblName, 400);
+    lv_label_set_long_mode(lblName, LV_LABEL_LONG_DOT);
+    lv_label_set_text(lblName, entity.friendly_name[0]
+                                   ? entity.friendly_name
+                                   : entity.entity_id);
+
+    /* State — top right */
+    lv_obj_t* lblState = lv_label_create(card);
+    lv_obj_set_style_text_font(lblState, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(lblState, isPlaying ? STATE_ON : TEXT_DIM, 0);
+    lv_obj_align(lblState, LV_ALIGN_TOP_RIGHT, 0, 2);
+    lv_label_set_text(lblState, entity.state);
+
+    /* Media title — bottom row */
+    if (entity.extra.media.media_title[0]) {
+        lv_obj_t* lblTitle = lv_label_create(card);
+        lv_obj_set_style_text_font(lblTitle, &lv_font_montserrat_14, 0);
+        lv_obj_set_style_text_color(lblTitle, ACCENT, 0);
+        lv_obj_align(lblTitle, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+        lv_obj_set_width(lblTitle, 500);
+        lv_label_set_long_mode(lblTitle, LV_LABEL_LONG_DOT);
+        char buf[80];
+        if (entity.extra.media.app_name[0]) {
+            snprintf(buf, sizeof(buf), "%s \xE2\x80\xA2 %s",
+                     entity.extra.media.app_name, entity.extra.media.media_title);
+        } else {
+            snprintf(buf, sizeof(buf), "%s", entity.extra.media.media_title);
+        }
+        lv_label_set_text(lblTitle, buf);
+    } else if (entity.extra.media.app_name[0]) {
+        lv_obj_t* lblApp = lv_label_create(card);
+        lv_obj_set_style_text_font(lblApp, &lv_font_montserrat_14, 0);
+        lv_obj_set_style_text_color(lblApp, TEXT_DIM, 0);
+        lv_obj_align(lblApp, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+        lv_label_set_text(lblApp, entity.extra.media.app_name);
+    }
+}
+
+/* ─── Generic Row: lock, cover, person, etc. ─── */
+void HAScreen::addGenericRow(lv_obj_t* parent, const HAEntity& entity) {
+    lv_obj_t* row = lv_obj_create(parent);
+    lv_obj_set_size(row, 720, 28);
     lv_obj_set_style_bg_opa(row, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(row, 0, 0);
     lv_obj_set_style_pad_all(row, 2, 0);
@@ -101,9 +326,7 @@ void HAScreen::addEntityRow(lv_obj_t* parent, const HAEntity& entity) {
     /* Color based on state */
     bool isOn = (strcmp(entity.state, "on") == 0 ||
                  strcmp(entity.state, "home") == 0 ||
-                 strcmp(entity.state, "locked") == 0 ||
-                 strcmp(entity.state, "heating") == 0 ||
-                 strcmp(entity.state, "cooling") == 0);
+                 strcmp(entity.state, "locked") == 0);
     bool isOff = (strcmp(entity.state, "off") == 0 ||
                   strcmp(entity.state, "away") == 0 ||
                   strcmp(entity.state, "unlocked") == 0);
@@ -115,6 +338,7 @@ void HAScreen::addEntityRow(lv_obj_t* parent, const HAEntity& entity) {
         lv_obj_set_style_text_color(lblState, TEXT_SECONDARY, 0);
 }
 
+/* ─── Domain Group Container ─── */
 void HAScreen::addDomainGroup(const char* domain, const HAEntity* entities,
                                const uint8_t* indices, uint8_t count) {
     lv_obj_t* group = lv_obj_create(_entityList);
@@ -150,9 +374,23 @@ void HAScreen::addDomainGroup(const char* domain, const HAEntity* entities,
     snprintf(hdrBuf, sizeof(hdrBuf), "%s (%d)", domainLabel(domain), count);
     lv_label_set_text(lblDomain, hdrBuf);
 
-    /* Entity rows */
+    /* Entity cards — dispatched by domain */
     for (uint8_t i = 0; i < count; i++) {
-        addEntityRow(group, entities[indices[i]]);
+        const HAEntity& ent = entities[indices[i]];
+        if (strcmp(domain, "climate") == 0) {
+            addClimateCard(group, ent);
+        } else if (strcmp(domain, "sensor") == 0 ||
+                   strcmp(domain, "binary_sensor") == 0) {
+            addSensorRow(group, ent);
+        } else if (strcmp(domain, "light") == 0 ||
+                   strcmp(domain, "switch") == 0 ||
+                   strcmp(domain, "fan") == 0) {
+            addLightSwitchRow(group, ent);
+        } else if (strcmp(domain, "media_player") == 0) {
+            addMediaCard(group, ent);
+        } else {
+            addGenericRow(group, ent);
+        }
     }
 }
 
@@ -204,7 +442,6 @@ void HAScreen::rebuildEntityList(const HAData& ha) {
 
 void HAScreen::onShow() {
     if (!_lastData) return;
-    /* Rebuild entity list from stored data when screen becomes visible */
     if (_lastData->home_assistant.status == SourceStatus::OK) {
         rebuildEntityList(_lastData->home_assistant.data);
     } else {


### PR DESCRIPTION
## Summary
- Replace flat HA entity list with domain-specific widget card renderers (climate, sensor, light/switch, media, generic fallback)
- Expand `HAEntity` struct with union for domain-specific extras (climate temps/HVAC, sensor units, media titles) — ~72 bytes per entity
- Extend `dashboard_data.cpp` parser to extract domain attributes from bridge JSON
- Climate cards show current/target temp with colored HVAC action dot (orange=heating, blue=cooling, gray=idle)
- Light/switch rows show colored on/off indicator dot; media cards show now-playing info

## Test plan
- [x] Build compiles cleanly (RAM 79.5%, Flash 25.0%)
- [x] Flashed to CrowPanel — boots and renders
- [ ] Verify HA screen shows domain-specific cards with live Home Assistant data
- [ ] Confirm climate thermostat card displays temps and HVAC action correctly
- [ ] Confirm sensor rows show values with units
- [ ] Confirm light/switch toggles show colored on/off dots

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)