### PR TITLE
infra: add unified CI gate for required status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+# =============================================================================
+# CI — Unified gate for all PRs
+# =============================================================================
+# Always runs on every PR so it can serve as a required status check.
+# Detects which paths changed and runs the appropriate checks.
+# If no relevant paths changed, reports success immediately.
+# =============================================================================
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  # ── Path detection ─────────────────────────────────────────────
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      bridge: ${{ steps.filter.outputs.bridge }}
+      firmware: ${{ steps.filter.outputs.firmware }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            bridge:
+              - 'bridge/**'
+              - 'pyproject.toml'
+            firmware:
+              - 'firmware/**'
+
+  # ── Bridge: ruff lint + mypy + pytest ──────────────────────────
+  bridge-lint:
+    needs: changes
+    if: needs.changes.outputs.bridge == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install ruff mypy types-PyMySQL
+          pip install -r bridge/requirements.txt
+      - name: Lint with ruff
+        run: ruff check bridge/ --exclude bridge/tests/
+      - name: Type check with mypy
+        run: mypy bridge/main.py --ignore-missing-imports
+
+  bridge-test:
+    needs: [changes, bridge-lint]
+    if: needs.changes.outputs.bridge == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install pytest pytest-asyncio httpx
+          pip install -r bridge/requirements.txt
+      - name: Run tests
+        run: PYTHONPATH=bridge pytest bridge/tests/ -v --tb=short
+
+  # ── Firmware: PlatformIO build ─────────────────────────────────
+  firmware-build:
+    needs: changes
+    if: needs.changes.outputs.firmware == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio
+            firmware/.pio
+          key: pio-${{ hashFiles('firmware/platformio.ini') }}
+          restore-keys: pio-
+      - name: Install PlatformIO
+        run: pip install platformio
+      - name: Build firmware
+        working-directory: firmware
+        run: pio run --environment crowpanel5
+
+  # ── Gate job: always runs, always reports ──────────────────────
+  # This is the ONLY required status check on the branch protection.
+  # It waits for whichever sub-checks ran and reports their result.
+  ci:
+    runs-on: ubuntu-latest
+    needs: [changes, bridge-lint, bridge-test, firmware-build]
+    if: always()
+    steps:
+      - name: Evaluate results
+        run: |
+          echo "Bridge changed: ${{ needs.changes.outputs.bridge }}"
+          echo "Firmware changed: ${{ needs.changes.outputs.firmware }}"
+
+          # Check if any job that actually ran has failed
+          BRIDGE_LINT="${{ needs.bridge-lint.result }}"
+          BRIDGE_TEST="${{ needs.bridge-test.result }}"
+          FIRMWARE="${{ needs.firmware-build.result }}"
+
+          FAILED=false
+          for JOB in "$BRIDGE_LINT" "$BRIDGE_TEST" "$FIRMWARE"; do
+            if [ "$JOB" = "failure" ]; then
+              FAILED=true
+            fi
+          done
+
+          if [ "$FAILED" = "true" ]; then
+            echo "::error::One or more checks failed"
+            echo "  bridge-lint: $BRIDGE_LINT"
+            echo "  bridge-test: $BRIDGE_TEST"
+            echo "  firmware-build: $FIRMWARE"
+            exit 1
+          fi
+
+          echo "✅ All checks passed (or skipped — no relevant files changed)"


### PR DESCRIPTION
## Summary
Fixes the deadlock where path-filtered CI (`lint`/`test`) never reports on PRs that don't touch `bridge/` or `firmware/`, blocking required status checks.

- New `ci.yml` always runs on every PR
- Uses `dorny/paths-filter` to detect bridge/firmware changes
- Runs sub-checks only when relevant paths changed
- Gate job `ci` always reports pass/fail — serves as the sole required check
- Branch protection updated: requires `ci` (not `lint`/`test`)

## Why this matters
DCC's `lint` and `test` were set as required checks, but they only trigger on `bridge/**` and `firmware/**` paths. Workflow-only PRs (like Tollgate 2) would deadlock — checks never ran, PR could never merge.

## Test plan
- [ ] This PR itself validates the fix — it only touches workflow files, so bridge/firmware checks should be skipped, but `ci` gate should pass
- [ ] Future bridge PRs should still run lint+test
- [ ] Future firmware PRs should still run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)