### PR TITLE
infra: session infrastructure parity with Unfocused

### DIFF
--- a/.claude/hooks/preflight.sh
+++ b/.claude/hooks/preflight.sh
@@ -1,104 +1,232 @@
 #!/usr/bin/env bash
-# Desktop Command Center — Session Preflight Check
-# Validates infrastructure before agent session begins.
-# Exit 0 = pass, Exit 2 = blocking failure
+# =============================================================================
+# Desktop Command Center — CLI Agent Pre-flight Check
+# =============================================================================
+# Runs on SessionStart. Blocks the session (exit 2) if required coordination
+# services are unavailable. Auto-starts the Dolt SSH tunnel if it's down.
+#
+# Required services:
+#   1. Dolt SSH tunnel (localhost → Hetzner:3307) — for Beads task tracking
+#   2. MCP Agent Mail (getunfocused.app/mcp/) — for multi-agent coordination
+#
+# Zombie port detection:
+#   If a previous session's SSH tunnel died without closing its socket,
+#   the port stays LISTENING with a dead PID. This hook detects that and
+#   falls back to alternate ports (3308, 3309).
+#
+# Exit codes:
+#   0 = all checks passed, session may proceed
+#   2 = BLOCKING — required service unavailable, session must not start
+# =============================================================================
 
 set -euo pipefail
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+HETZNER_HOST="unfocused@46.224.181.82"
+DOLT_PORTS=(3307 3308 3309)  # Cascade: try each until one works
+AGENT_MAIL_HEALTH="https://getunfocused.app/health/liveness"
+PID_FILE="$HOME/.dcc-tunnel.pid"
 
-pass() { echo -e "${GREEN}✓${NC} $1"; }
-warn() { echo -e "${YELLOW}⚠${NC} $1"; }
-fail() { echo -e "${RED}✗${NC} $1"; }
+PASS="✓"
+FAIL="✗"
+WARN="⚠"
+errors=0
 
-BLOCKING=0
+log()  { echo "$@" >&2; }
+pass() { log "$PASS $1"; }
+fail() { log "$FAIL $1"; errors=$((errors + 1)); }
+warn() { log "$WARN $1"; }
 
-echo "─── Desktop Command Center: Preflight ───"
+log ""
+log "═══ Desktop Command Center Pre-flight Check ═══"
+log ""
 
-# 1. Check Beads/Dolt connectivity (Pi 5 tunnel)
-# Try DCC tunnel ports (3310 primary, 3311-3312 fallback)
-TUNNEL_PORT=""
-for port in 3310 3311 3312; do
-    if bash -c "echo >/dev/tcp/127.0.0.1/$port" 2>/dev/null; then
-        TUNNEL_PORT=$port
-        break
+# ─── Helper: check if a PID is a live process ─────────────────────────────
+pid_alive() {
+  local pid=$1
+  # tasklist on Windows — returns 0 if process exists
+  if tasklist //FI "PID eq $pid" 2>/dev/null | grep -q "$pid"; then
+    return 0
+  fi
+  return 1
+}
+
+# ─── Helper: check if port is listening AND the PID is alive ──────────────
+port_healthy() {
+  local port=$1
+  local pid
+  pid=$(netstat -ano 2>/dev/null | grep "127.0.0.1:${port}" | grep -i "listen" | awk '{print $NF}' | head -1)
+
+  if [ -z "$pid" ]; then
+    return 1  # Port not listening at all
+  fi
+
+  if pid_alive "$pid"; then
+    return 0  # Port listening with a live process — healthy
+  else
+    warn "Port $port held by zombie PID $pid (process dead, socket orphaned)"
+    return 1
+  fi
+}
+
+# ─── Helper: kill old tunnel from PID file ────────────────────────────────
+cleanup_old_tunnel() {
+  if [ -f "$PID_FILE" ]; then
+    local old_pid
+    old_pid=$(cat "$PID_FILE" 2>/dev/null || true)
+    if [ -n "$old_pid" ] && pid_alive "$old_pid"; then
+      log "  Killing previous tunnel (PID $old_pid)..."
+      taskkill //F //PID "$old_pid" 2>/dev/null || kill "$old_pid" 2>/dev/null || true
+      sleep 1
     fi
+    rm -f "$PID_FILE"
+  fi
+}
+
+# ─── 1. Dolt SSH Tunnel ─────────────────────────────────────────────────────
+# Beads connects to Dolt via localhost. This requires an SSH tunnel
+# forwarding to the Hetzner server where Dolt runs.
+
+ACTIVE_PORT=""
+
+# First, try to clean up any previous tunnel
+cleanup_old_tunnel
+
+# Try each port in the cascade
+for port in "${DOLT_PORTS[@]}"; do
+  if port_healthy "$port"; then
+    ACTIVE_PORT=$port
+    pass "Dolt SSH tunnel (port $port — existing healthy tunnel)"
+    break
+  fi
+
+  # Port not healthy (either not listening or zombie). Try to start tunnel.
+  # -o ExitOnForwardFailure=yes = fail immediately if port is already bound
+  if ssh -o ExitOnForwardFailure=yes -fNL "${port}:127.0.0.1:3307" "$HETZNER_HOST" 2>/dev/null; then
+    sleep 2
+    if port_healthy "$port"; then
+      # Save the PID for cleanup by next session
+      local_pid=$(netstat -ano 2>/dev/null | grep "127.0.0.1:${port}" | grep -i "listen" | awk '{print $NF}' | head -1)
+      echo "$local_pid" > "$PID_FILE"
+      ACTIVE_PORT=$port
+      pass "Dolt SSH tunnel (auto-started on port $port)"
+      break
+    fi
+  fi
+
+  # This port didn't work (zombie or bind failure), try next
+  if [ "$port" != "${DOLT_PORTS[-1]}" ]; then
+    warn "Port $port unavailable, trying next..."
+  fi
 done
 
-if [ -n "$TUNNEL_PORT" ]; then
-    pass "Pi 5 Dolt tunnel active on port $TUNNEL_PORT"
-    # Try a beads command
-    if bd ready --limit=1 >/dev/null 2>&1; then
-        pass "Beads connectivity OK (Pi 5 Dolt)"
-        bd dolt pull 2>/dev/null && pass "Beads synced" || warn "Beads sync failed (non-blocking)"
+if [ -z "$ACTIVE_PORT" ]; then
+  fail "Dolt SSH tunnel — all ports (${DOLT_PORTS[*]}) failed"
+  log "  Zombie ports may require system reboot to release."
+  log "  Manual fix: ssh -fNL 3307:127.0.0.1:3307 ${HETZNER_HOST}"
+fi
+
+# ─── 2. Beads Connectivity ──────────────────────────────────────────────────
+# Verify Beads can actually talk to Dolt through the tunnel.
+
+if [ -n "$ACTIVE_PORT" ]; then
+  export PATH="/c/Dev/flutter/bin:$PATH"
+  export BD_DSN="root:@tcp(127.0.0.1:${ACTIVE_PORT})/Desk_Command_Center"
+
+  if bd list --quiet 2>/dev/null | head -1 >/dev/null 2>&1; then
+    pass "Beads (bd list via port $ACTIVE_PORT)"
+
+    # ─── 2b. Pull latest Beads data from Dolt remote ─────────────
+    # Prevents agents from starting with stale task state.
+    # Warning only — stale data is better than a blocked session.
+    #
+    # Auto-commit metadata first: `dolt push` writes tracking data to
+    # the metadata table outside SQL transactions, leaving dirty state
+    # that blocks all future pulls. Commit it silently before pulling.
+    ssh -o ConnectTimeout=5 "$HETZNER_HOST" \
+      "docker exec dolt-beads dolt --data-dir=/var/lib/dolt sql -q \
+       \"USE Desk_Command_Center; CALL dolt_add('metadata'); CALL dolt_commit('-m', 'chore: auto-commit metadata before pull', '--allow-empty');\"" \
+      2>/dev/null || true
+
+    if bd dolt pull 2>/dev/null; then
+      pass "Beads data synced (bd dolt pull)"
     else
-        fail "Beads command failed — tunnel may be stale"
-        BLOCKING=1
+      warn "bd dolt pull failed — session may have stale Beads data"
+      log "  This is a warning, not a blocker. Continuing."
     fi
+  else
+    # Tunnel is up but Beads can't connect — maybe Dolt server isn't running
+    fail "Beads cannot reach Dolt (tunnel up but Dolt may not be running)"
+    log "  Check Dolt on server: ssh ${HETZNER_HOST} \"docker ps | grep dolt\""
+  fi
+fi
+
+# ─── 3. MCP Agent Mail ──────────────────────────────────────────────────────
+# Agent Mail runs on Hetzner, accessed via HTTPS through Cloudflare/nginx.
+
+if curl -s --connect-timeout 5 "$AGENT_MAIL_HEALTH" 2>/dev/null | grep -q "alive"; then
+  pass "Agent Mail (${AGENT_MAIL_HEALTH})"
 else
-    # Try to establish tunnel automatically
-    if ssh -fNL 3310:127.0.0.1:3306 strycher@192.168.50.24 2>/dev/null; then
-        pass "Pi 5 Dolt tunnel established on port 3310"
-        if bd ready --limit=1 >/dev/null 2>&1; then
-            pass "Beads connectivity OK (Pi 5 Dolt)"
-        else
-            fail "Beads command failed after tunnel setup"
-            BLOCKING=1
-        fi
-    else
-        fail "No Pi 5 Dolt SSH tunnel on ports 3310-3312"
-        warn "Start tunnel: ssh -fNL 3310:127.0.0.1:3306 strycher@192.168.50.24"
-        BLOCKING=1
+  fail "Agent Mail is unreachable"
+  log "  Check: ssh ${HETZNER_HOST} \"cd /opt/mcp_agent_mail && docker compose -f docker-compose.prod.yml logs --tail 20\""
+  log "  Restart: ssh ${HETZNER_HOST} \"cd /opt/mcp_agent_mail && docker compose -f docker-compose.prod.yml down && docker compose -f docker-compose.prod.yml up -d\""
+fi
+
+# ─── 4. Git Hooks Path ─────────────────────────────────────────────────────
+# Ensure core.hookspath points to .claude/hooks/ (tracked, works in worktrees).
+# .beads/hooks/ is gitignored and doesn't exist in worktrees → no hooks run.
+
+HOOKS_PATH=$(cd /c/Dev/Desk_Command_Center && git config core.hookspath 2>/dev/null || echo "")
+if [ "$HOOKS_PATH" = ".claude/hooks" ]; then
+  pass "Git hooks path (.claude/hooks — tracked, worktree-safe)"
+else
+  warn "Git hooks path is '${HOOKS_PATH:-<unset>}' — fixing to .claude/hooks"
+  cd /c/Dev/Desk_Command_Center && git config core.hookspath .claude/hooks
+  pass "Git hooks path fixed to .claude/hooks"
+fi
+
+# ─── 5. Abandoned Worktree Detection ──────────────────────────────────────
+# Scan for worktrees that might be leftovers from crashed agent sessions.
+# Warning only — don't auto-delete (might have uncommitted work).
+
+ABANDONED=()
+while IFS= read -r wt_line; do
+  wt_path=$(echo "$wt_line" | awk '{print $1}')
+  wt_branch=$(echo "$wt_line" | awk '{print $2}' | tr -d '[]')
+
+  # Skip bare repo and main worktree
+  if [ "$wt_path" = "/c/Dev/Desk_Command_Center" ] || [ "$wt_path" = "/c/Dev/Desk_Command_Center-main" ]; then
+    continue
+  fi
+
+  # Skip if it looks like a known pattern but check age
+  if [ -d "$wt_path" ]; then
+    # Check last commit time in the worktree
+    LAST_COMMIT=$(cd "$wt_path" 2>/dev/null && git log -1 --format=%ct 2>/dev/null || echo "0")
+    NOW=$(date +%s)
+    AGE_HOURS=$(( (NOW - LAST_COMMIT) / 3600 ))
+
+    if [ "$AGE_HOURS" -gt 24 ]; then
+      ABANDONED+=("$wt_path (branch: $wt_branch, last commit: ${AGE_HOURS}h ago)")
     fi
+  fi
+done < <(cd /c/Dev/Desk_Command_Center && git worktree list 2>/dev/null | grep -v "^$")
+
+if [ ${#ABANDONED[@]} -gt 0 ]; then
+  warn "Found ${#ABANDONED[@]} potentially abandoned worktree(s):"
+  for wt in "${ABANDONED[@]}"; do
+    log "    $wt"
+  done
+  log "  To clean up: git worktree remove <path> && git branch -d <branch>"
+  log "  These may contain uncommitted work from crashed agent sessions."
 fi
 
-# 2. Check Agent Mail health
-AGENT_MAIL_OK=0
-for url in "http://localhost:8912/health/liveness" "https://getunfocused.app/health/liveness"; do
-    if curl -sf --max-time 5 "$url" >/dev/null 2>&1; then
-        pass "Agent Mail reachable at $url"
-        AGENT_MAIL_OK=1
-        break
-    fi
-done
+# ─── 6. Claude Heartbeat to Bridge ──────────────────────────────────────────
+# DCC-specific: send heartbeat to the Pi5 bridge for status display.
 
-if [ "$AGENT_MAIL_OK" -eq 0 ]; then
-    # Try MCP tool check (may be available as MCP server)
-    warn "Agent Mail HTTP check failed — will verify via MCP tools"
-fi
-
-# 3. Check Git status
-cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || cd "$(dirname "$0")/../.."
-
-BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
-if [ "$BRANCH" = "main" ]; then
-    pass "On main branch"
-else
-    warn "On branch '$BRANCH' (not main)"
-fi
-
-if git diff --quiet 2>/dev/null && git diff --cached --quiet 2>/dev/null; then
-    pass "Working tree clean"
-else
-    warn "Uncommitted changes detected"
-fi
-
-# 4. Check git hooks path
-HOOKSPATH=$(git config core.hookspath 2>/dev/null || echo "")
-if [ "$HOOKSPATH" = ".claude/hooks" ]; then
-    pass "Git hooks configured"
-else
-    warn "Git hooks not configured — run: git config core.hookspath .claude/hooks"
-fi
-
-# 5. Send Claude heartbeat to bridge
 BRIDGE_URL="http://192.168.50.24:8080"
 AGENT_NAME=""
-if [ -f "$CLAUDE_PROJECT_DIR/.agent-identity" ]; then
-    AGENT_NAME=$(cat "$CLAUDE_PROJECT_DIR/.agent-identity" 2>/dev/null | tr -d '[:space:]')
+if [ -f "${CLAUDE_PROJECT_DIR:-.}/.agent-identity" ]; then
+    AGENT_NAME=$(cat "${CLAUDE_PROJECT_DIR:-.}/.agent-identity" 2>/dev/null | tr -d '[:space:]')
 fi
 if [ -z "$AGENT_NAME" ]; then
     AGENT_NAME="Claude-$$"
@@ -109,11 +237,49 @@ curl -sf --max-time 3 -X POST "$BRIDGE_URL/api/claude/heartbeat" \
     -d "{\"agent\": \"$AGENT_NAME\", \"task\": \"Session starting\", \"program\": \"claude-code\"}" \
     >/dev/null 2>&1 && pass "Claude heartbeat sent ($AGENT_NAME)" || warn "Claude heartbeat failed (non-blocking)"
 
-echo "─── Preflight complete ───"
+# ─── 7. Session State (Compaction Recovery) ──────────────────────────────────
+# If an agent session is active, output its state. This output becomes a
+# system reminder that survives context compaction, allowing the agent to
+# recover its working context (current epic, task, branch, budget).
 
-if [ "$BLOCKING" -eq 1 ]; then
-    fail "BLOCKING: Infrastructure checks failed. Fix issues above before proceeding."
-    exit 2
+# Resolve script path relative to this file (works in any worktree)
+PREFLIGHT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SESSION_STATE_SCRIPT="$PREFLIGHT_DIR/session-state.sh"
+SESSION_STATE_FILE="/c/Dev/Desk_Command_Center/.claude/agent-session.json"
+
+if [ -f "$SESSION_STATE_FILE" ] && [ -f "$SESSION_STATE_SCRIPT" ]; then
+  SESSION_OUTPUT=$(bash "$SESSION_STATE_SCRIPT" read 2>/dev/null || true)
+  if [ -n "$SESSION_OUTPUT" ]; then
+    log ""
+    log "═══ Active Agent Session ═══"
+    log ""
+    while IFS= read -r line; do
+      log "  $line"
+    done <<< "$SESSION_OUTPUT"
+    log ""
+    log "  This session state was recovered from disk."
+    log "  If /work was invoked, resume your current task."
+    log "  If this is a new interactive session, ignore this — run"
+    log "  'bash .claude/hooks/session-state.sh reset' to clear stale state."
+    log ""
+  fi
 fi
 
+# ─── Result ──────────────────────────────────────────────────────────────────
+
+log ""
+if [ "$errors" -gt 0 ]; then
+  log "═══ BLOCKED: $errors check(s) failed ═══"
+  log "Fix the issues above, then retry. Agents must not operate without"
+  log "Beads (task coordination) and Agent Mail (file reservation)."
+  log ""
+  exit 2
+fi
+
+if [ -n "$ACTIVE_PORT" ]; then
+  log "  Export: BD_DSN=root:@tcp(127.0.0.1:${ACTIVE_PORT})/Desk_Command_Center"
+fi
+
+log "═══ All checks passed — session ready ═══"
+log ""
 exit 0

--- a/.claude/hooks/session-state.sh
+++ b/.claude/hooks/session-state.sh
@@ -1,0 +1,525 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Desktop Command Center — Agent Session State Manager
+# =============================================================================
+# Manages a persistent session state file that survives context compaction.
+# The preflight hook reads this file and outputs it as a system reminder,
+# allowing agents to recover their working context after compaction.
+#
+# Usage:
+#   session-state.sh <subcommand> [options]
+#
+# Subcommands:
+#   init            Create a new session (fails if one already exists)
+#   read            Output session state as formatted text
+#   update-task     Set the current task being worked on
+#   clear-task      Clear current task (between tasks)
+#   record-create   Record a Beads task creation
+#   record-close    Record a task completion (increments counter)
+#   record-pr       Record a PR creation
+#   update-pr-state Update a PR's merge state
+#   check-duplicate Check if a task title was already created this session
+#   advance-epic    Move to the next epic in the queue
+#   check-budget    Check if task budget is exhausted
+#   reset           Delete the session file (cleanup)
+#
+# Exit codes:
+#   0 = success / check passed
+#   1 = error or check failed (duplicate found, session exists, etc.)
+#   2 = HARD STOP — agent must cease all work (budget exhausted, queue empty)
+# =============================================================================
+
+set -euo pipefail
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+SESSION_FILE="/c/Dev/Desk_Command_Center/.claude/agent-session.json"
+SESSION_TMP="${SESSION_FILE}.tmp"
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+die()  { echo "ERROR: $1" >&2; exit "${2:-1}"; }
+info() { echo "$@" >&2; }
+
+# Atomic write: write to .tmp then move into place
+atomic_write() {
+  local content="$1"
+  echo "$content" > "$SESSION_TMP"
+  mv -f "$SESSION_TMP" "$SESSION_FILE"
+}
+
+# Read the session file, or die if it doesn't exist
+read_session() {
+  if [ ! -f "$SESSION_FILE" ]; then
+    die "No active session (${SESSION_FILE} not found)" 1
+  fi
+  cat "$SESSION_FILE"
+}
+
+# Python helper: takes a Python script on stdin, passes session JSON as arg
+py_session() {
+  local py_script="$1"
+  shift
+  python3 -c "$py_script" "$@"
+}
+
+# ─── Subcommand: init ────────────────────────────────────────────────────────
+# Creates a new session. Refuses to overwrite an existing session.
+#
+# Options:
+#   --agent <name>       Agent Mail name (required)
+#   --epics <id,...>     Comma-separated epic IDs (optional)
+#   --max-tasks <N>      Task budget, 0=unlimited (optional, default 0)
+#
+# Exit: 0=created, 1=session already exists (use 'read' to recover)
+
+cmd_init() {
+  local agent="" epics="" max_tasks=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --agent)    agent="$2"; shift 2 ;;
+      --epics)    epics="$2"; shift 2 ;;
+      --max-tasks) max_tasks="$2"; shift 2 ;;
+      *) die "init: unknown option '$1'" ;;
+    esac
+  done
+
+  [ -z "$agent" ] && die "init: --agent is required"
+
+  # Block re-init if session already exists
+  if [ -f "$SESSION_FILE" ]; then
+    info "Session already exists. Use 'read' to recover state."
+    exit 1
+  fi
+
+  local now
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  py_session '
+import json, sys
+
+agent = sys.argv[1]
+epics_raw = sys.argv[2]
+max_tasks = int(sys.argv[3])
+started = sys.argv[4]
+
+epic_list = [e.strip() for e in epics_raw.split(",") if e.strip()] if epics_raw else []
+
+session = {
+    "session_id": f"{agent}-{started}",
+    "agent_name": agent,
+    "started_at": started,
+    "epic_queue": epic_list,
+    "current_epic": epic_list[0] if epic_list else None,
+    "max_tasks": max_tasks,
+    "current_task": None,
+    "tasks_completed": 0,
+    "tasks_created_this_session": [],
+    "prs_created": []
+}
+
+print(json.dumps(session, indent=2))
+' "$agent" "$epics" "$max_tasks" "$now" > "$SESSION_TMP"
+
+  mv -f "$SESSION_TMP" "$SESSION_FILE"
+  info "Session initialized: agent=$agent, epics=${epics:-none}, max_tasks=${max_tasks}"
+}
+
+# ─── Subcommand: read ────────────────────────────────────────────────────────
+# Outputs the session state as formatted text suitable for a system reminder.
+# Exit: 0=ok, 1=no session
+
+cmd_read() {
+  local session
+  session=$(read_session) || exit 1
+
+  py_session '
+import json, sys
+
+try:
+    s = json.loads(sys.stdin.read())
+except (json.JSONDecodeError, KeyError):
+    print("Session file is corrupted", file=sys.stderr)
+    sys.exit(1)
+
+lines = []
+agent = s.get("agent_name", "unknown")
+lines.append("Agent: " + agent)
+
+# Epic queue
+eq = s.get("epic_queue", [])
+ce = s.get("current_epic")
+if eq:
+    parts = []
+    for e in eq:
+        if e == ce:
+            parts.append(e + " (current)")
+        else:
+            parts.append(e)
+    lines.append("Epic Queue: " + ", ".join(parts))
+elif ce:
+    lines.append("Current Epic: " + ce)
+else:
+    lines.append("Epic Queue: unrestricted (all ready tasks)")
+
+# Current task
+ct = s.get("current_task")
+if ct and isinstance(ct, dict):
+    tid = ct.get("id", "?")
+    ttl = ct.get("title", "?")
+    lines.append("Current Task: " + tid + " - " + repr(ttl))
+    branch = ct.get("branch")
+    if branch:
+        lines.append("  Branch: " + branch)
+    wt = ct.get("worktree")
+    if wt:
+        lines.append("  Worktree: " + wt)
+else:
+    lines.append("Current Task: none (between tasks)")
+
+# Budget
+completed = s.get("tasks_completed", 0)
+max_t = s.get("max_tasks", 0)
+if max_t > 0:
+    lines.append("Tasks Completed: " + str(completed) + " of " + str(max_t) + " max")
+else:
+    lines.append("Tasks Completed: " + str(completed) + " (no limit)")
+
+# PRs
+prs = s.get("prs_created", [])
+if prs:
+    pr_strs = []
+    for p in prs:
+        num = str(p.get("number", "?"))
+        state = p.get("state", "open")
+        pr_strs.append("#" + num + " (" + state + ")")
+    lines.append("PRs: " + ", ".join(pr_strs))
+
+# Tasks created
+tc = s.get("tasks_created_this_session", [])
+if tc:
+    ids = [t.get("id", "?") for t in tc]
+    lines.append("Tasks Created This Session: " + ", ".join(ids))
+
+for line in lines:
+    print(line)
+' <<< "$session"
+}
+
+# ─── Subcommand: update-task ─────────────────────────────────────────────────
+# Options: --id, --title, --branch, --worktree
+
+cmd_update_task() {
+  local id="" title="" branch="" worktree=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --id)       id="$2"; shift 2 ;;
+      --title)    title="$2"; shift 2 ;;
+      --branch)   branch="$2"; shift 2 ;;
+      --worktree) worktree="$2"; shift 2 ;;
+      *) die "update-task: unknown option '$1'" ;;
+    esac
+  done
+
+  local session
+  session=$(read_session) || exit 1
+
+  local result
+  result=$(py_session '
+import json, sys
+s = json.loads(sys.stdin.read())
+now_str = sys.argv[1]
+tid = sys.argv[2]
+title = sys.argv[3]
+branch = sys.argv[4]
+wt = sys.argv[5]
+
+s["current_task"] = {
+    "id": tid,
+    "title": title,
+    "branch": branch,
+    "worktree": wt,
+    "claimed_at": now_str
+}
+print(json.dumps(s, indent=2))
+' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$id" "$title" "$branch" "$worktree" <<< "$session")
+
+  atomic_write "$result"
+  info "Current task set: $id"
+}
+
+# ─── Subcommand: clear-task ──────────────────────────────────────────────────
+
+cmd_clear_task() {
+  local session
+  session=$(read_session) || exit 1
+
+  local result
+  result=$(py_session '
+import json, sys
+s = json.loads(sys.stdin.read())
+s["current_task"] = None
+print(json.dumps(s, indent=2))
+' <<< "$session")
+
+  atomic_write "$result"
+  info "Current task cleared"
+}
+
+# ─── Subcommand: record-create ───────────────────────────────────────────────
+# Options: --id, --title
+
+cmd_record_create() {
+  local id="" title=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --id)    id="$2"; shift 2 ;;
+      --title) title="$2"; shift 2 ;;
+      *) die "record-create: unknown option '$1'" ;;
+    esac
+  done
+
+  local session
+  session=$(read_session) || exit 1
+
+  local result
+  result=$(py_session '
+import json, sys
+s = json.loads(sys.stdin.read())
+tid = sys.argv[1]
+title = sys.argv[2]
+s.setdefault("tasks_created_this_session", []).append({"id": tid, "title": title})
+print(json.dumps(s, indent=2))
+' "$id" "$title" <<< "$session")
+
+  atomic_write "$result"
+  info "Recorded task creation: $id"
+}
+
+# ─── Subcommand: record-close ────────────────────────────────────────────────
+
+cmd_record_close() {
+  local session
+  session=$(read_session) || exit 1
+
+  local result
+  result=$(py_session '
+import json, sys
+s = json.loads(sys.stdin.read())
+s["tasks_completed"] = s.get("tasks_completed", 0) + 1
+s["current_task"] = None
+print(json.dumps(s, indent=2))
+' <<< "$session")
+
+  atomic_write "$result"
+  info "Task closed. Total completed: $(echo "$result" | python3 -c 'import json,sys; print(json.load(sys.stdin)["tasks_completed"])')"
+}
+
+# ─── Subcommand: record-pr ───────────────────────────────────────────────────
+# Options: --number, --branch
+
+cmd_record_pr() {
+  local number="" branch=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --number) number="$2"; shift 2 ;;
+      --branch) branch="$2"; shift 2 ;;
+      *) die "record-pr: unknown option '$1'" ;;
+    esac
+  done
+
+  local session
+  session=$(read_session) || exit 1
+
+  local result
+  result=$(py_session '
+import json, sys
+s = json.loads(sys.stdin.read())
+num = int(sys.argv[1])
+branch = sys.argv[2]
+s.setdefault("prs_created", []).append({"number": num, "branch": branch, "state": "open"})
+print(json.dumps(s, indent=2))
+' "$number" "$branch" <<< "$session")
+
+  atomic_write "$result"
+  info "Recorded PR #$number"
+}
+
+# ─── Subcommand: update-pr-state ─────────────────────────────────────────────
+# Options: --number, --state (open|merged|closed)
+
+cmd_update_pr_state() {
+  local number="" state=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --number) number="$2"; shift 2 ;;
+      --state)  state="$2"; shift 2 ;;
+      *) die "update-pr-state: unknown option '$1'" ;;
+    esac
+  done
+
+  local session
+  session=$(read_session) || exit 1
+
+  local result
+  result=$(py_session '
+import json, sys
+s = json.loads(sys.stdin.read())
+num = int(sys.argv[1])
+new_state = sys.argv[2]
+for pr in s.get("prs_created", []):
+    if pr.get("number") == num:
+        pr["state"] = new_state
+        break
+print(json.dumps(s, indent=2))
+' "$number" "$state" <<< "$session")
+
+  atomic_write "$result"
+  info "PR #$number → $state"
+}
+
+# ─── Subcommand: check-duplicate ─────────────────────────────────────────────
+# Options: --title <fragment>
+# Exit: 0=no duplicate, 1=duplicate found
+
+cmd_check_duplicate() {
+  local title=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --title) title="$2"; shift 2 ;;
+      *) die "check-duplicate: unknown option '$1'" ;;
+    esac
+  done
+
+  [ -z "$title" ] && die "check-duplicate: --title is required"
+
+  local session
+  session=$(read_session) || exit 1
+
+  py_session '
+import json, sys
+s = json.loads(sys.stdin.read())
+fragment = sys.argv[1].lower()
+for t in s.get("tasks_created_this_session", []):
+    if fragment in t.get("title", "").lower():
+        ttl = t.get("title", "?")
+        tid = t.get("id", "?")
+        print("DUPLICATE: " + repr(ttl) + " (id: " + tid + ")", file=sys.stderr)
+        sys.exit(1)
+sys.exit(0)
+' "$title" <<< "$session"
+}
+
+# ─── Subcommand: advance-epic ────────────────────────────────────────────────
+# Moves current_epic to the next in the queue.
+# Exit: 0=advanced, 2=queue empty (HARD STOP)
+
+cmd_advance_epic() {
+  local session
+  session=$(read_session) || exit 1
+
+  local exit_code
+  exit_code=0
+
+  local result
+  result=$(py_session '
+import json, sys
+s = json.loads(sys.stdin.read())
+queue = s.get("epic_queue", [])
+current = s.get("current_epic")
+
+if not queue:
+    # No queue — unrestricted mode, nothing to advance
+    print(json.dumps(s, indent=2))
+    sys.exit(2)
+
+try:
+    idx = queue.index(current)
+except ValueError:
+    idx = -1
+
+next_idx = idx + 1
+if next_idx < len(queue):
+    s["current_epic"] = queue[next_idx]
+    print(json.dumps(s, indent=2))
+    print(f"Advanced to epic: {queue[next_idx]}", file=sys.stderr)
+    sys.exit(0)
+else:
+    print(json.dumps(s, indent=2))
+    print("Epic queue exhausted — all epics processed.", file=sys.stderr)
+    sys.exit(2)
+' <<< "$session") || exit_code=$?
+
+  if [ $exit_code -eq 0 ]; then
+    atomic_write "$result"
+  elif [ $exit_code -eq 2 ]; then
+    info "HARD STOP: Epic queue exhausted."
+    exit 2
+  fi
+}
+
+# ─── Subcommand: check-budget ────────────────────────────────────────────────
+# Exit: 0=under budget, 2=budget exhausted (HARD STOP)
+
+cmd_check_budget() {
+  local session
+  session=$(read_session) || exit 1
+
+  py_session '
+import json, sys
+s = json.loads(sys.stdin.read())
+max_t = s.get("max_tasks", 0)
+completed = s.get("tasks_completed", 0)
+
+if max_t <= 0:
+    # No budget limit
+    sys.exit(0)
+
+if completed >= max_t:
+    print(f"BUDGET EXHAUSTED: {completed}/{max_t} tasks completed.", file=sys.stderr)
+    sys.exit(2)
+else:
+    remaining = max_t - completed
+    print(f"Budget OK: {completed}/{max_t} completed, {remaining} remaining.", file=sys.stderr)
+    sys.exit(0)
+' <<< "$session"
+}
+
+# ─── Subcommand: reset ───────────────────────────────────────────────────────
+
+cmd_reset() {
+  if [ -f "$SESSION_FILE" ]; then
+    rm -f "$SESSION_FILE" "$SESSION_TMP"
+    info "Session state cleared"
+  else
+    info "No session to clear"
+  fi
+}
+
+# ─── Dispatch ─────────────────────────────────────────────────────────────────
+
+SUBCOMMAND="${1:-}"
+shift 2>/dev/null || true
+
+case "$SUBCOMMAND" in
+  init)             cmd_init "$@" ;;
+  read)             cmd_read ;;
+  update-task)      cmd_update_task "$@" ;;
+  clear-task)       cmd_clear_task ;;
+  record-create)    cmd_record_create "$@" ;;
+  record-close)     cmd_record_close ;;
+  record-pr)        cmd_record_pr "$@" ;;
+  update-pr-state)  cmd_update_pr_state "$@" ;;
+  check-duplicate)  cmd_check_duplicate "$@" ;;
+  advance-epic)     cmd_advance_epic ;;
+  check-budget)     cmd_check_budget ;;
+  reset)            cmd_reset ;;
+  "")               die "Usage: session-state.sh <subcommand> [options]" ;;
+  *)                die "Unknown subcommand: $SUBCOMMAND" ;;
+esac


### PR DESCRIPTION
## Summary
- Fixed preflight.sh: Dolt tunnel now targets Hetzner (was Pi5 192.168.50.24:3310)
- Added zombie port detection (pid_alive/port_healthy), port cascade (3307-3309), PID file cleanup
- Added BD_DSN export with `Desk_Command_Center` database (no `beads_` prefix)
- Added Beads dolt pull with metadata auto-commit
- Added git hooks path check pointing to `/c/Dev/Desk_Command_Center`
- Added abandoned worktree detection (skips primary repo and -main)
- Kept DCC-specific bridge heartbeat section (Pi5 bridge at 192.168.50.24:8080)
- Added session state recovery (Section 7) for compaction recovery
- Added session-state.sh for /work mode compaction recovery (ported from Unfocused, path updated)

Part of Tollgate 3 — infrastructure parity.

## Test plan
- [ ] Verify SSH tunnel auto-starts to Hetzner on port 3307
- [ ] Verify `bd list` works after preflight
- [ ] Verify bridge heartbeat still fires
- [ ] Verify session-state.sh init/read/reset cycle works

🤖 Generated with [Claude Code](https://claude.com/claude-code)