### PR TITLE
fix: HA device cap, device_tracker visibility, climate modal feedback

### DIFF
--- a/bridge/main.py
+++ b/bridge/main.py
@@ -15,6 +15,7 @@ Endpoints:
   GET  /calendar/google     — retrieve latest Google calendar snapshot
 """
 
+import asyncio
 import logging
 import time
 from contextlib import asynccontextmanager
@@ -251,12 +252,33 @@ async def ha_command(request: Request):
             "error": f"Service call failed: {exc}",
         })
 
-    # Re-fetch entity state
+    # Re-fetch entity state (climate needs retries — Z-Wave/Zigbee propagation)
+    entity = None
     try:
-        entity = await ha_adapter.get_entity_state(entity_id)
+        if domain == "climate":
+            await asyncio.sleep(1.0)
+            for attempt in range(3):
+                entity = await ha_adapter.get_entity_state(entity_id)
+                # Check if state reflects the command
+                expected_mode = (data or {}).get("hvac_mode")
+                expected_temp = (data or {}).get("temperature")
+                current_state = entity.get("state")
+                current_temp = entity.get("target_temp")
+                if expected_mode and str(current_state) == str(expected_mode):
+                    break
+                if expected_temp and str(current_temp) == str(expected_temp):
+                    break
+                if not expected_mode and not expected_temp:
+                    break  # preset_mode or other — no easy check
+                await asyncio.sleep(1.0)
+        else:
+            entity = await ha_adapter.get_entity_state(entity_id)
     except Exception as exc:
         logger.warning("HA state refetch failed: %s", exc)
         return {"success": True, "entity": None, "warning": "State refetch failed"}
+
+    # Refresh scheduler cache so the next /api/dashboard poll sees fresh data
+    asyncio.ensure_future(scheduler.poll_once(ha_adapter))
 
     return {"success": True, "entity": entity}
 

--- a/docs/plans/2026-03-14-sse-realtime-design.md
+++ b/docs/plans/2026-03-14-sse-realtime-design.md
@@ -1,0 +1,380 @@
+# SSE Real-Time Data Delivery — Design
+
+> **Date:** 2026-03-14
+> **Status:** Approved
+> **Replaces:** HTTP polling as primary data path
+> **Tracks:** New issues TBD
+
+---
+
+## Problem
+
+The firmware polls `GET /api/dashboard` every 30 seconds. The bridge polls
+Home Assistant's REST API (`GET /api/states`) every 60 seconds. This means a
+physical device state change (e.g., turning on a light) can take up to 90
+seconds to appear on the DCC display. For an interactive control panel, this
+latency makes the UI feel broken — especially after tapping a control and
+waiting for confirmation.
+
+Additionally, polling wastes bandwidth and CPU on both sides when nothing has
+changed, while missing rapid state transitions entirely.
+
+## Solution
+
+Three-layer upgrade:
+
+1. **Bridge subscribes to HA WebSocket** for instant state_changed events
+2. **Bridge exposes a unified SSE endpoint** (`GET /api/events`) that pushes
+   updates to connected clients
+3. **Firmware runs an SSE client task** that receives updates in real time
+
+Polling is retained as a safety net at reduced frequency, not removed.
+
+---
+
+## Section 1: Bridge — HA WebSocket Event Subscription
+
+### Current Behavior
+
+`HomeAssistantAdapter.poll()` calls `GET {ha_url}/api/states` every 60 seconds,
+parses all entity states, filters by DCC label, and updates the adapter cache.
+The entity/device registry refreshes on a separate 300-second timer via a
+one-shot WebSocket call.
+
+### New Behavior
+
+The bridge maintains a **persistent WebSocket connection** to
+`ws://{ha_url}/api/websocket`, authenticating with the existing long-lived
+access token. After auth, it subscribes to `state_changed` events.
+
+**Event processing:**
+
+1. On `state_changed` event, check if the entity is DCC-labeled (using the
+   cached registry). If not, discard.
+2. Add the changed entity to a **pending-changes buffer** (dict keyed by
+   entity_id — later changes overwrite earlier ones for the same entity).
+3. Start a **500ms debounce timer**. If a timer is already running, reset it.
+4. When the timer fires: merge all pending changes into the cached HA data,
+   clear the buffer, and push an SSE `update` event to all connected clients.
+
+The debounce prevents event storms (e.g., a scene activation changing 10
+entities in rapid succession) from flooding the firmware with 10 separate
+updates.
+
+**Reconnection:**
+
+If the WebSocket drops, reconnect with exponential backoff (1s, 2s, 4s, ...
+capped at 60s). During the gap, the existing 60s REST poll continues as a
+safety net — no data is lost, just delayed.
+
+**Registry refresh** stays on the existing 300-second timer. The WebSocket
+is used only for state_changed events, not registry discovery.
+
+### Rationale
+
+- HA's WebSocket API is the officially supported real-time interface
+- Debouncing prevents redundant SSE pushes during scene/automation bursts
+- Keeping the REST poll as fallback means a WebSocket bug never causes a
+  total data outage
+
+---
+
+## Section 2: Bridge — Unified SSE Endpoint
+
+### Endpoint
+
+```
+GET /api/events
+Accept: text/event-stream
+Last-Event-ID: <optional, integer>
+```
+
+### Client Management
+
+The bridge maintains a list of connected SSE clients (asyncio queues). Any
+cache update from any adapter source triggers an SSE event to all connected
+clients. Client disconnection is detected via write failure and cleaned up.
+
+### Event Types
+
+| Event Type    | Payload                                                    | When Sent                                    |
+|---------------|------------------------------------------------------------|----------------------------------------------|
+| `snapshot`    | Full dashboard JSON (same schema as `GET /api/dashboard`)  | On initial connect, or stale reconnect       |
+| `update`      | `{"source": "<name>", "data": {...}}`                      | Any single-source cache update               |
+| `heartbeat`   | Empty data field                                           | Every 15 seconds                             |
+
+**Wire format example:**
+
+```
+id: 42
+event: update
+data: {"source": "home_assistant", "data": {"devices": [...]}}
+
+id: 43
+event: heartbeat
+data:
+
+```
+
+### Event IDs and Replay
+
+- Event IDs are **monotonic integers**, starting at 1 on bridge startup.
+- The bridge keeps a **rolling buffer of ~200 recent events**.
+- On reconnect with `Last-Event-ID` header:
+  - If the ID is within the buffer: replay all missed `update` events in order.
+  - If the gap exceeds 100 events or the ID is not in the buffer: send a
+    fresh `snapshot` instead of replaying.
+- This avoids unbounded memory growth while supporting brief disconnections.
+
+### What Triggers Events
+
+| Trigger                              | Event Type | Source Field         |
+|--------------------------------------|------------|----------------------|
+| HA WebSocket state_changed (debounced) | `update` | `home_assistant`     |
+| Any adapter poll completes           | `update`   | adapter name         |
+| Push endpoint receives data          | `update`   | `claude` / caller    |
+| HA command response after cache refresh | `update` | `home_assistant`   |
+| Timer tick (15s)                     | `heartbeat` | —                   |
+| Client connects / stale reconnect    | `snapshot`  | —                   |
+
+### Implementation Notes
+
+- Use Starlette's `EventSourceResponse` (or `sse-starlette` package) for
+  async SSE streaming in FastAPI.
+- Each connected client gets an `asyncio.Queue`. Events are broadcast by
+  iterating the client list and putting into each queue.
+- Heartbeat is an `asyncio.create_task` loop, not per-client.
+
+---
+
+## Section 3: Firmware — SSE Client
+
+### New Module
+
+`firmware/include/sse_client.h` / `firmware/src/sse_client.cpp`
+
+### FreeRTOS Task
+
+A dedicated task pinned to **Core 0**, alongside the existing network task.
+
+```cpp
+xTaskCreatePinnedToCore(
+    sseTask,        // function
+    "sse",          // name
+    6144,           // stack size (6 KB — parsing buffer in PSRAM)
+    nullptr,        // parameter
+    1,              // priority
+    &_sseHandle,    // handle
+    0               // Core 0
+);
+```
+
+The SSE parsing buffer (for accumulating event data lines) is allocated in
+**PSRAM** to avoid stack pressure. The 6 KB stack covers the task frame,
+`HTTPClient`, and local variables.
+
+### Connection Lifecycle
+
+1. **Connect** to `GET /api/events` with `Accept: text/event-stream`.
+   Include `Last-Event-ID` header if reconnecting.
+2. **Receive `snapshot`** on first connect → full dashboard parse via the
+   same code path as the current poll (`deserializeJson` → copy to
+   `DashboardData` → set `_dataReady`).
+3. **Receive `update` events** → partial parse. Only the changed source
+   block is updated in `DashboardData` (e.g., if `source` is
+   `home_assistant`, only HA fields are overwritten).
+4. **Receive `heartbeat`** → reset watchdog timer. No data processing.
+5. **No heartbeat for 30 seconds** → assume connection dead. Close and
+   reconnect.
+
+### Reconnection
+
+Exponential backoff: 1s → 2s → 4s → 8s → 16s → 30s (cap). Reset to 1s
+on successful connection (first event received).
+
+During disconnection, the existing poll loop continues as fallback.
+
+### Integration with DataService
+
+- `DataService` poll loop interval increases from 30s to **120 seconds**
+  (safety net only — SSE is the primary path).
+- SSE task writes to the **same `_doc` / `_dataReady` mechanism** — LVGL
+  updates flow through the same `checkReady()` call on Core 1.
+- `forcePoll()` still works for immediate refresh after HA commands.
+- The `_dataMutex` protects concurrent access between SSE task, network
+  task, and main loop (same mutex, three potential writers).
+
+### SSE Parser
+
+Minimal line-based parser for the SSE wire format:
+
+1. Read lines from HTTP stream.
+2. Lines starting with `event:` set the current event type.
+3. Lines starting with `data:` append to the data buffer.
+4. Lines starting with `id:` store the last event ID.
+5. Empty line = event boundary → dispatch based on event type.
+6. Lines starting with `:` are comments (ignore).
+
+No external SSE library needed — the format is simple enough for a ~100-line
+parser.
+
+### API
+
+```cpp
+namespace SSEClient {
+    void init(const char* bridgeUrl);
+    void startTask();
+    void stop();
+    bool isConnected();
+    uint32_t lastEventMs();
+}
+```
+
+---
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `bridge/adapters/home_assistant.py` | Add WebSocket subscription, debounce buffer, reconnection logic |
+| `bridge/sse.py` | **New** — SSE manager: client list, event buffer, broadcast, heartbeat |
+| `bridge/main.py` | Register SSE endpoint, wire HA WebSocket events to SSE manager |
+| `firmware/include/sse_client.h` | **New** — SSE client API |
+| `firmware/src/sse_client.cpp` | **New** — FreeRTOS task, SSE parser, reconnection |
+| `firmware/include/data_service.h` | Expose mutex for SSE task; adjust default interval |
+| `firmware/src/data_service.cpp` | Increase poll interval to 120s; share `_dataMutex` |
+| `firmware/src/main.cpp` | `SSEClient::init()` + `startTask()` in setup |
+| `firmware/include/dashboard_data.h` | Add partial-update method for single-source refresh |
+| `firmware/src/dashboard_data.cpp` | Implement partial-update parsing |
+
+---
+
+## Constraints
+
+- **PSRAM required** for SSE parsing buffer — no large heap allocations in SRAM
+- **Single writer at a time** on `DashboardData` — mutex arbitrates between
+  SSE task, network task, and (future) command response path
+- **No binary protocol** — SSE is text-based, human-debuggable with curl
+- **Bridge must handle N clients** — but in practice, only 1 DCC device connects
+- **Event buffer bounded at ~200** — prevents unbounded memory growth on the Pi
+- **Heartbeat interval (15s) < watchdog timeout (30s)** — ensures detection
+  before the firmware gives up
+
+---
+
+## Task Breakdown
+
+Tasks are ordered by dependency. Each task touches 1–3 files and targets
+15–30 minutes of implementation time.
+
+### Task 1: Bridge SSE Manager Module
+
+**Files:** `bridge/sse.py` (new)
+
+Create the SSE infrastructure: client registration, event ID counter,
+rolling event buffer (~200), broadcast function, heartbeat loop (15s),
+and `Last-Event-ID` replay logic (replay if gap <= 100, else snapshot).
+No endpoint wiring yet — just the manager class.
+
+**Depends on:** Nothing
+
+---
+
+### Task 2: Bridge SSE Endpoint
+
+**Files:** `bridge/main.py`
+
+Add `GET /api/events` endpoint using the SSE manager from Task 1.
+Wire existing adapter cache updates to trigger SSE broadcast. Send
+`snapshot` on initial connect. Add `sse-starlette` to requirements if
+needed.
+
+**Depends on:** Task 1
+
+---
+
+### Task 3: Bridge HA WebSocket Subscription
+
+**Files:** `bridge/adapters/home_assistant.py`
+
+Add persistent WebSocket connection to HA (`ws://.../api/websocket`).
+Subscribe to `state_changed` events. Implement pending-changes buffer
+with 500ms debounce timer. On timer fire, merge changes into cached
+data and call the SSE manager's broadcast. Implement reconnection with
+exponential backoff (1s–60s). Existing 60s REST poll remains as fallback.
+
+**Depends on:** Task 1 (needs SSE manager to broadcast)
+
+---
+
+### Task 4: Firmware SSE Parser
+
+**Files:** `firmware/include/sse_client.h` (new), `firmware/src/sse_client.cpp` (new)
+
+Implement line-based SSE wire format parser: event type, data
+accumulation, event ID tracking, empty-line dispatch. Allocate parsing
+buffer in PSRAM. No network connection yet — just the parser logic and
+the public API (`init`, `startTask`, `stop`, `isConnected`,
+`lastEventMs`).
+
+**Depends on:** Nothing (can parallel with Tasks 1–3)
+
+---
+
+### Task 5: Firmware Partial Dashboard Update
+
+**Files:** `firmware/include/dashboard_data.h`, `firmware/src/dashboard_data.cpp`
+
+Add a method to `DashboardData` (or the parsing namespace) that accepts
+a source name and a JSON object, and updates only that source's fields
+in the cached data. Reuses existing per-source parsing logic. This is
+the `update` event handler path.
+
+**Depends on:** Nothing (can parallel with Tasks 1–4)
+
+---
+
+### Task 6: Firmware SSE Task + DataService Integration
+
+**Files:** `firmware/src/sse_client.cpp`, `firmware/src/data_service.cpp`, `firmware/include/data_service.h`
+
+Wire the SSE parser into a FreeRTOS task on Core 0. Connect to
+`/api/events`, handle `snapshot` (full parse), `update` (partial parse
+from Task 5), and `heartbeat` (watchdog reset). Implement reconnection
+with exponential backoff. Share `_dataMutex` with DataService. Increase
+DataService poll interval to 120s.
+
+**Depends on:** Task 4, Task 5
+
+---
+
+### Task 7: Firmware Main Loop Integration
+
+**Files:** `firmware/src/main.cpp`
+
+Add `SSEClient::init()` and `SSEClient::startTask()` to `setup()`.
+No changes to `loop()` — SSE writes through the existing `_dataReady`
+/ `checkReady()` mechanism.
+
+**Depends on:** Task 6
+
+---
+
+### Dependency Graph
+
+```
+Task 1 (SSE Manager)
+  ├→ Task 2 (SSE Endpoint)
+  └→ Task 3 (HA WebSocket)
+
+Task 4 (SSE Parser)  ──┐
+Task 5 (Partial Update) ┤
+                        ├→ Task 6 (SSE Task + DataService)
+                        │    └→ Task 7 (Main Loop Integration)
+                        │
+Tasks 1–3 (bridge)  ────┘  (firmware tasks need bridge running to test)
+```
+
+Tasks 1–3 (bridge-side) and Tasks 4–5 (firmware-side) can be developed
+in parallel. Task 6 integrates both sides. Task 7 is a small wiring
+commit that finalizes the feature.

--- a/firmware/include/dashboard_data.h
+++ b/firmware/include/dashboard_data.h
@@ -12,7 +12,7 @@ static constexpr uint8_t MAX_TASKS  = 20;
 static constexpr uint8_t MAX_REPOS  = 10;
 static constexpr uint8_t MAX_HA_ENTITIES = 40;
 static constexpr uint8_t MAX_HA_PER_DOMAIN = 6;
-static constexpr uint8_t MAX_HA_DEVICES = 16;
+static constexpr uint8_t MAX_HA_DEVICES = MAX_HA_ENTITIES;  // each device has ≥1 entity
 static constexpr uint8_t MAX_HOURLY = 12;
 static constexpr uint8_t MAX_DAILY  = 5;
 

--- a/firmware/src/dashboard_data.cpp
+++ b/firmware/src/dashboard_data.cpp
@@ -290,7 +290,6 @@ void DashboardParser::parse(const JsonDocument& doc, DashboardData& out) {
                 /* ── Label mode: device-grouped entities ── */
                 JsonArrayConst devArr = haData["devices"];
                 for (JsonObjectConst dev : devArr) {
-                    if (out.home_assistant.data.device_count >= MAX_HA_DEVICES) break;
                     if (out.home_assistant.data.entity_count >= MAX_HA_ENTITIES) break;
 
                     HADeviceGroup& grp = out.home_assistant.data.devices[out.home_assistant.data.device_count];

--- a/firmware/src/ui/ha_control_modal.cpp
+++ b/firmware/src/ui/ha_control_modal.cpp
@@ -46,6 +46,11 @@ static char _entityId[64]   = {};
 static char _domain[16]     = {};
 static char _currentState[32] = {};
 
+/* Climate mode buttons (for re-highlighting on result) */
+static constexpr uint8_t CLIMATE_MODE_COUNT = 3;
+static const char* _climateModes[] = {"heat", "cool", "off"};
+static lv_obj_t* _modeBtns[CLIMATE_MODE_COUNT] = {};
+
 /* -- Forward declarations -- */
 static void buildToggleBody(lv_obj_t* body);
 static void buildClimateBody(lv_obj_t* body, const HAEntity& entity);
@@ -280,6 +285,7 @@ void HAControlModal::close() {
         _lblState = nullptr;
         _lblToast = nullptr;
         _lblTarget = nullptr;
+        for (uint8_t i = 0; i < CLIMATE_MODE_COUNT; i++) _modeBtns[i] = nullptr;
     }
     LOG_INFO("MODAL: closed");
 }
@@ -298,24 +304,48 @@ void HAControlModal::onCommandResult(bool success, const char* newState,
         /* Update stored state */
         strncpy(_currentState, newState, sizeof(_currentState) - 1);
 
-        /* Update state label */
+        /* Update state label (domain-aware) */
         if (_lblState) {
             char buf[48];
-            bool isOn = (strcmp(newState, "on") == 0 ||
-                         strcmp(newState, "home") == 0);
-            if (strcmp(_domain, "lock") == 0) {
+            if (strcmp(_domain, "climate") == 0) {
+                bool isHeat = (strcmp(newState, "heat") == 0 ||
+                               strcmp(newState, "heat_cool") == 0);
+                bool isCool = (strcmp(newState, "cool") == 0);
+                bool isOff  = (strcmp(newState, "off") == 0);
+                snprintf(buf, sizeof(buf), "Mode: %s", newState);
+                lv_label_set_text(_lblState, buf);
+                lv_obj_set_style_text_color(_lblState,
+                    isHeat ? HEAT_CLR : isCool ? COOL_CLR
+                    : isOff ? STATE_OFF_CLR : TEXT_PRI, 0);
+            } else if (strcmp(_domain, "lock") == 0) {
                 bool locked = (strcmp(newState, "locked") == 0);
                 snprintf(buf, sizeof(buf), "State: %s %s",
                          locked ? LV_SYMBOL_CLOSE : LV_SYMBOL_OK,
                          locked ? "Locked" : "Unlocked");
+                lv_label_set_text(_lblState, buf);
+                lv_obj_set_style_text_color(_lblState,
+                    locked ? STATE_OFF_CLR : STATE_ON_CLR, 0);
             } else {
+                bool isOn = (strcmp(newState, "on") == 0 ||
+                             strcmp(newState, "home") == 0);
                 snprintf(buf, sizeof(buf), "State: %s %s",
                          isOn ? LV_SYMBOL_OK : LV_SYMBOL_CLOSE,
                          isOn ? "On" : "Off");
+                lv_label_set_text(_lblState, buf);
+                lv_obj_set_style_text_color(_lblState,
+                    isOn ? STATE_ON_CLR : STATE_OFF_CLR, 0);
             }
-            lv_label_set_text(_lblState, buf);
-            lv_obj_set_style_text_color(_lblState,
-                                        isOn ? STATE_ON_CLR : STATE_OFF_CLR, 0);
+        }
+
+        /* Re-highlight climate mode buttons */
+        if (strcmp(_domain, "climate") == 0) {
+            for (uint8_t i = 0; i < CLIMATE_MODE_COUNT; i++) {
+                if (_modeBtns[i]) {
+                    bool active = (strcmp(newState, _climateModes[i]) == 0);
+                    lv_obj_set_style_bg_color(_modeBtns[i],
+                        active ? BTN_ACTIVE : BTN_BG, 0);
+                }
+            }
         }
 
         /* Show success toast */
@@ -452,8 +482,24 @@ static void buildClimateBody(lv_obj_t* body, const HAEntity& entity) {
     lv_obj_center(lblU);
     lv_obj_add_event_cb(btnUp, onTempUp, LV_EVENT_CLICKED, nullptr);
 
+    /* Mode state label (updated by onCommandResult) */
+    _lblState = lv_label_create(body);
+    lv_obj_set_style_text_font(_lblState, &lv_font_montserrat_14, 0);
+    lv_obj_align(_lblState, LV_ALIGN_TOP_RIGHT, 0, 4);
+    {
+        bool isHeat = (strcmp(entity.state, "heat") == 0 ||
+                       strcmp(entity.state, "heat_cool") == 0);
+        bool isCool = (strcmp(entity.state, "cool") == 0);
+        bool isOff  = (strcmp(entity.state, "off") == 0);
+        char mbuf[32];
+        snprintf(mbuf, sizeof(mbuf), "Mode: %s", entity.state);
+        lv_label_set_text(_lblState, mbuf);
+        lv_obj_set_style_text_color(_lblState,
+            isHeat ? HEAT_CLR : isCool ? COOL_CLR
+            : isOff ? STATE_OFF_CLR : TEXT_PRI, 0);
+    }
+
     /* HVAC mode buttons */
-    static const char* modes[] = {"heat", "cool", "off"};
     static const char* modeLabels[] = {"Heat", "Cool", "Off"};
     int16_t btnW = 90;
     int16_t startX = (PANEL_W - 24 - btnW * 3 - 16) / 2;
@@ -464,12 +510,12 @@ static void buildClimateBody(lv_obj_t* body, const HAEntity& entity) {
     lv_obj_align(lblMode, LV_ALIGN_TOP_LEFT, 0, 92);
     lv_label_set_text(lblMode, "Mode:");
 
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < CLIMATE_MODE_COUNT; i++) {
         lv_obj_t* btn = lv_btn_create(body);
         lv_obj_set_size(btn, btnW, 34);
         lv_obj_set_pos(btn, startX + i * (btnW + 8), 110);
 
-        bool active = (strcmp(entity.state, modes[i]) == 0);
+        bool active = (strcmp(entity.state, _climateModes[i]) == 0);
         lv_obj_set_style_bg_color(btn, active ? BTN_ACTIVE : BTN_BG, 0);
         lv_obj_set_style_radius(btn, 6, 0);
 
@@ -480,7 +526,8 @@ static void buildClimateBody(lv_obj_t* body, const HAEntity& entity) {
         lv_obj_center(lbl);
 
         lv_obj_add_event_cb(btn, onHvacMode, LV_EVENT_CLICKED,
-                            (void*)modes[i]);
+                            (void*)_climateModes[i]);
+        _modeBtns[i] = btn;
     }
 
     /* Preset buttons (if preset_mode is available) */

--- a/firmware/src/ui/screens/ha_screen.cpp
+++ b/firmware/src/ui/screens/ha_screen.cpp
@@ -607,8 +607,8 @@ void HAScreen::addMultiEntityCard(lv_obj_t* parent, const HADeviceGroup& grp,
     for (uint8_t i = 0; i < grp.entity_count; i++) {
         const HAEntity& ent = entities[grp.entity_start + i];
 
-        /* Skip device_tracker entities with router source_type */
-        if (strcmp(ent.domain, "device_tracker") == 0) continue;
+        /* device_tracker entities are kept — useful for routers,
+           network devices, and other non-person trackers */
 
         const char* sname = shortEntityName(ent, grp.device_name);
 


### PR DESCRIPTION
## Summary
- **Router visibility**: Removed blanket `device_tracker` skip in multi-entity cards — DCC-labeled entities always show regardless of domain
- **Device cap removed**: `MAX_HA_DEVICES` now equals `MAX_HA_ENTITIES` (40) — no artificial truncation, list scrolls
- **Climate modal feedback**: Mode buttons re-highlight on result, state label shows "Mode: heat/cool/off" with colored text instead of generic "On/Off"
- **Bridge climate retry**: After HVAC service calls, retries state refetch up to 3× with 1s delays to catch thermostat propagation
- **SSE design doc**: Architecture spec for real-time event streaming (approved, not yet implemented)

## Test plan
- [ ] Verify router appears on HA screen (DCC label applied)
- [ ] Verify >16 HA devices render without truncation
- [ ] Test HVAC mode change (Heat→Cool) — modal should show correct mode + color
- [ ] Test temperature change — verify updated value reflects within ~3s
- [ ] Confirm calendar data flowing after Google OAuth re-auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)