### PR TITLE
fix(#208): skip device key check when key not configured

### DIFF
--- a/bridge/main.py
+++ b/bridge/main.py
@@ -226,7 +226,8 @@ async def dashboard(request: Request):
             cache_keys[key] = key
     else:
         device = config.get_device(device_id)
-        if device is not None and device.get("key") != device_key:
+        registered_key = device.get("key", "") if device else ""
+        if device is not None and registered_key and registered_key != (device_key or ""):
             return JSONResponse(status_code=403, content={"error": "Invalid device key"})
 
         if device is None:


### PR DESCRIPTION
## Summary
- Devices with empty key in config were getting 403 (None != "")
- Now skips key validation when the registered device has no key set
- Already deployed and validated on Pi 5

## Test plan
- [x] Device 2CF913E08898 now gets 200 OK from bridge
- [x] Bridge serves per-user filtered dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)