### PR TITLE
feat(#57): Monday.com tasks adapter

### DIFF
--- a/bridge/adapters/monday.py
+++ b/bridge/adapters/monday.py
@@ -1,0 +1,140 @@
+"""Monday.com tasks adapter — fetches board items via GraphQL API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from .base import AdapterConfig, BaseAdapter
+
+logger = logging.getLogger(__name__)
+
+MONDAY_API_URL = "https://api.monday.com/v2"
+
+# GraphQL query: fetch items from specified boards with key columns
+ITEMS_QUERY = """
+query ($board_ids: [ID!]!) {
+  boards(ids: $board_ids) {
+    id
+    name
+    items_page(limit: 50) {
+      items {
+        id
+        name
+        state
+        column_values {
+          id
+          text
+          type
+        }
+      }
+    }
+  }
+}
+"""
+
+
+class MondayAdapter(BaseAdapter):
+    """Polls Monday.com boards for task items via GraphQL API.
+
+    Config from BridgeConfig:
+      monday.api_token: Monday.com API token
+      monday.board_ids: list of board IDs to fetch
+      monday.poll_interval: seconds between polls (default 300)
+    """
+
+    def __init__(self, source_config: dict[str, Any]) -> None:
+        poll_interval = source_config.get("poll_interval", 300)
+
+        super().__init__(
+            name="monday",
+            config=AdapterConfig(
+                poll_interval=poll_interval,
+                ttl=poll_interval * 3,
+                max_retries=2,
+                backoff_base=5.0,
+                backoff_max=120.0,
+            ),
+        )
+        self.api_token: str = source_config.get("api_token", "")
+        self.board_ids: list[str] = [
+            str(bid) for bid in source_config.get("board_ids", [])
+        ]
+
+    async def poll(self) -> dict[str, Any]:
+        if not self.api_token:
+            raise ValueError("Monday.com API token not configured")
+        if not self.board_ids:
+            raise ValueError("No Monday.com board IDs configured")
+
+        headers = {
+            "Authorization": self.api_token,
+            "Content-Type": "application/json",
+            "API-Version": "2024-10",
+        }
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                MONDAY_API_URL,
+                headers=headers,
+                json={
+                    "query": ITEMS_QUERY,
+                    "variables": {"board_ids": self.board_ids},
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+        if "errors" in data:
+            raise RuntimeError(f"Monday.com API error: {data['errors']}")
+
+        return data.get("data", {})
+
+    def parse(self, raw: dict[str, Any]) -> dict[str, Any]:
+        boards = []
+        total_items = 0
+
+        for board in raw.get("boards", []):
+            board_name = board.get("name", "Unknown Board")
+            board_id = board.get("id", "")
+            items = []
+
+            for item in board.get("items_page", {}).get("items", []):
+                if item.get("state") == "deleted":
+                    continue
+
+                columns = {
+                    cv["id"]: cv["text"]
+                    for cv in item.get("column_values", [])
+                    if cv.get("text")
+                }
+
+                # Extract common fields from column values
+                status = columns.get("status", columns.get("status_1", ""))
+                due_date = columns.get("date", columns.get("date4", ""))
+                priority = columns.get("priority", "")
+
+                items.append({
+                    "id": item["id"],
+                    "title": item.get("name", ""),
+                    "status": status,
+                    "due_date": due_date,
+                    "priority": priority,
+                    "board": board_name,
+                })
+                total_items += 1
+
+            boards.append({
+                "id": board_id,
+                "name": board_name,
+                "item_count": len(items),
+                "items": items,
+            })
+
+        return {
+            "boards": boards,
+            "total_items": total_items,
+            "board_count": len(boards),
+        }

--- a/bridge/config.py
+++ b/bridge/config.py
@@ -28,7 +28,7 @@ SECRET_KEYS = re.compile(
 # Source keys that are per-user in multi-user mode
 _PER_USER_SOURCES = {
     "weather", "google_calendar", "github", "beads",
-    "unfocused_tasks", "claude", "claude_status", "devops",
+    "unfocused_tasks", "claude", "claude_status", "devops", "monday",
 }
 
 # Source keys that are shared across all users

--- a/bridge/main.py
+++ b/bridge/main.py
@@ -29,6 +29,7 @@ from adapters.base import BaseAdapter
 from adapters.beads import BeadsAdapter
 from adapters.claude_status import ClaudeStatusAdapter
 from adapters.github import GitHubAdapter
+from adapters.monday import MondayAdapter
 from adapters.google_calendar import GoogleCalendarAdapter
 from adapters.home_assistant import HomeAssistantAdapter
 from adapters.unfocused_tasks import UnfocusedTasksAdapter
@@ -49,6 +50,7 @@ ADAPTER_CLASSES: dict[str, type[BaseAdapter]] = {
     "unfocused_tasks": UnfocusedTasksAdapter,
     "home_assistant": HomeAssistantAdapter,
     "claude_status": ClaudeStatusAdapter,
+    "monday": MondayAdapter,
 }
 
 
@@ -124,6 +126,7 @@ SOURCE_LABELS = {
     "unfocused_tasks": "Unfocused Tasks",
     "claude": "Claude Agents",
     "claude_status": "Claude Agents",
+    "monday": "Monday.com",
 }
 
 # Push-based sources (not adapter-driven, always included)

--- a/bridge/tests/test_monday.py
+++ b/bridge/tests/test_monday.py
@@ -1,0 +1,210 @@
+"""Tests for Monday.com tasks adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from adapters.monday import MondayAdapter
+
+
+@pytest.fixture
+def adapter():
+    return MondayAdapter({
+        "api_token": "test-token-123",
+        "board_ids": ["12345", "67890"],
+        "poll_interval": 120,
+    })
+
+
+@pytest.fixture
+def adapter_no_token():
+    return MondayAdapter({
+        "board_ids": ["12345"],
+    })
+
+
+@pytest.fixture
+def adapter_no_boards():
+    return MondayAdapter({
+        "api_token": "test-token-123",
+    })
+
+
+@pytest.fixture
+def sample_api_response():
+    return {
+        "boards": [
+            {
+                "id": "12345",
+                "name": "Sprint Board",
+                "items_page": {
+                    "items": [
+                        {
+                            "id": "001",
+                            "name": "Fix login bug",
+                            "state": "active",
+                            "column_values": [
+                                {"id": "status", "text": "Working on it", "type": "status"},
+                                {"id": "date", "text": "2026-03-20", "type": "date"},
+                                {"id": "priority", "text": "High", "type": "color"},
+                            ],
+                        },
+                        {
+                            "id": "002",
+                            "name": "Add export feature",
+                            "state": "active",
+                            "column_values": [
+                                {"id": "status", "text": "Done", "type": "status"},
+                                {"id": "date", "text": "", "type": "date"},
+                                {"id": "priority", "text": "Medium", "type": "color"},
+                            ],
+                        },
+                        {
+                            "id": "003",
+                            "name": "Deleted task",
+                            "state": "deleted",
+                            "column_values": [],
+                        },
+                    ],
+                },
+            },
+            {
+                "id": "67890",
+                "name": "Backlog",
+                "items_page": {
+                    "items": [
+                        {
+                            "id": "004",
+                            "name": "Research caching",
+                            "state": "active",
+                            "column_values": [
+                                {"id": "status", "text": "", "type": "status"},
+                                {"id": "priority", "text": "Low", "type": "color"},
+                            ],
+                        },
+                    ],
+                },
+            },
+        ],
+    }
+
+
+class TestMondayAdapterInit:
+    def test_name(self, adapter):
+        assert adapter.name == "monday"
+
+    def test_config(self, adapter):
+        assert adapter.config.poll_interval == 120
+        assert adapter.api_token == "test-token-123"
+        assert adapter.board_ids == ["12345", "67890"]
+
+    def test_defaults(self):
+        a = MondayAdapter({})
+        assert a.config.poll_interval == 300
+        assert a.api_token == ""
+        assert a.board_ids == []
+
+    def test_board_ids_coerced_to_strings(self):
+        a = MondayAdapter({"api_token": "x", "board_ids": [123, 456]})
+        assert a.board_ids == ["123", "456"]
+
+
+class TestParse:
+    def test_parse_boards(self, adapter, sample_api_response):
+        result = adapter.parse(sample_api_response)
+        assert result["board_count"] == 2
+        assert result["total_items"] == 3  # deleted item excluded
+
+    def test_parse_items(self, adapter, sample_api_response):
+        result = adapter.parse(sample_api_response)
+        sprint_board = result["boards"][0]
+        assert sprint_board["name"] == "Sprint Board"
+        assert sprint_board["item_count"] == 2  # deleted excluded
+
+        item = sprint_board["items"][0]
+        assert item["title"] == "Fix login bug"
+        assert item["status"] == "Working on it"
+        assert item["due_date"] == "2026-03-20"
+        assert item["priority"] == "High"
+        assert item["board"] == "Sprint Board"
+
+    def test_parse_empty_columns(self, adapter, sample_api_response):
+        result = adapter.parse(sample_api_response)
+        backlog_item = result["boards"][1]["items"][0]
+        assert backlog_item["status"] == ""  # empty text filtered
+        assert backlog_item["due_date"] == ""
+
+    def test_parse_deleted_excluded(self, adapter, sample_api_response):
+        result = adapter.parse(sample_api_response)
+        sprint_items = result["boards"][0]["items"]
+        titles = [i["title"] for i in sprint_items]
+        assert "Deleted task" not in titles
+
+    def test_parse_empty(self, adapter):
+        result = adapter.parse({"boards": []})
+        assert result["board_count"] == 0
+        assert result["total_items"] == 0
+        assert result["boards"] == []
+
+    def test_parse_no_items_page(self, adapter):
+        raw = {"boards": [{"id": "1", "name": "Empty", "items_page": {"items": []}}]}
+        result = adapter.parse(raw)
+        assert result["boards"][0]["item_count"] == 0
+
+
+class TestPoll:
+    @pytest.mark.asyncio
+    async def test_poll_no_token_raises(self, adapter_no_token):
+        with pytest.raises(ValueError, match="API token not configured"):
+            await adapter_no_token.poll()
+
+    @pytest.mark.asyncio
+    async def test_poll_no_boards_raises(self, adapter_no_boards):
+        with pytest.raises(ValueError, match="No Monday.com board IDs"):
+            await adapter_no_boards.poll()
+
+    @pytest.mark.asyncio
+    async def test_poll_api_error_raises(self, adapter):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = lambda: None
+        mock_response.json.return_value = {
+            "errors": [{"message": "Authentication failed"}],
+        }
+
+        async def mock_post(*args, **kwargs):
+            return mock_response
+
+        with patch("adapters.monday.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = mock_post
+            mock_cls.return_value = mock_client
+
+            with pytest.raises(RuntimeError, match="Monday.com API error"):
+                await adapter.poll()
+
+    @pytest.mark.asyncio
+    async def test_poll_success(self, adapter, sample_api_response):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = lambda: None
+        mock_response.json.return_value = {"data": sample_api_response}
+
+        async def mock_post(*args, **kwargs):
+            return mock_response
+
+        with patch("adapters.monday.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = mock_post
+            mock_cls.return_value = mock_client
+
+            result = await adapter.poll()
+
+        assert "boards" in result
+        assert len(result["boards"]) == 2

--- a/bridge/tests/test_multi_user.py
+++ b/bridge/tests/test_multi_user.py
@@ -98,7 +98,7 @@ class TestAdapterFactory:
             create_adapter("nonexistent", {})
 
     def test_all_adapter_classes_registered(self):
-        expected = {"weather", "github", "google_calendar", "beads", "unfocused_tasks", "home_assistant", "claude_status"}
+        expected = {"weather", "github", "google_calendar", "beads", "unfocused_tasks", "home_assistant", "claude_status", "monday"}
         assert set(ADAPTER_CLASSES.keys()) == expected
 
     def test_shared_adapter_no_user_scope(self):


### PR DESCRIPTION
## Summary
- New `MondayAdapter` poll adapter using Monday.com GraphQL API v2024-10
- Fetches items from configured boards with title, status, due date, priority, board name
- Validates API token and board IDs before querying; raises clear errors if missing
- Filters deleted items, coerces board IDs to strings
- 14 new tests covering init, parse, poll (including error handling)

## Config
Add to `bridge_config.json` under `users.<id>.sources`:
```json
"monday": {
  "api_token": "<monday-api-token>",
  "board_ids": ["12345", "67890"],
  "poll_interval": 300
}
```

## Test plan
- [x] All 144 bridge tests pass (including 14 new)
- [ ] Configure API token and board IDs on Pi 5
- [ ] Verify items fetched from real Monday.com boards
- [ ] Confirm dashboard shows Monday.com source

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)