### PR TITLE
fix: sync workflow label transition bug + auto-done permissions

### DIFF
--- a/.github/workflows/sync-labels-to-board.yml
+++ b/.github/workflows/sync-labels-to-board.yml
@@ -5,14 +5,31 @@ name: Sync Labels to Project Board
 # This Action translates those labels into board field updates.
 on:
   issues:
-    types: [labeled]
+    types: [labeled, closed]
 
 jobs:
+  # Safety net: auto-apply board:done when issue is closed without it
+  auto-done:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    if: github.event.action == 'closed'
+    steps:
+      - name: Apply board:done to closed issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          labels=$(gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json labels -q '.labels[].name')
+          if ! echo "$labels" | grep -q "board:done"; then
+            gh issue edit ${{ github.event.issue.number }} --repo ${{ github.repository }} --add-label "board:done"
+          fi
+
   sync:
     runs-on: ubuntu-latest
     if: >-
+      github.event.action == 'labeled' && (
       startsWith(github.event.label.name, 'board:') ||
-      startsWith(github.event.label.name, 'priority:')
+      startsWith(github.event.label.name, 'priority:'))
     steps:
       - name: Sync label to project board
         uses: actions/github-script@v7
@@ -115,8 +132,15 @@ jobs:
             `;
 
             // ── Sync ALL board/priority labels ──────────────────────
-            const boardLabel = issueLabels.find(l => l.startsWith('board:') && STATUS_OPTIONS[l]);
-            const priorityLabel = issueLabels.find(l => l.startsWith('priority:') && PRIORITY_OPTIONS[l]);
+            // Use the trigger label directly when it matches — the payload's
+            // label array is a stale snapshot and find() may return the old
+            // label instead of the one that triggered this workflow run.
+            const boardLabel = triggerPrefix === 'board:'
+              ? triggerLabel
+              : issueLabels.find(l => l.startsWith('board:') && STATUS_OPTIONS[l]);
+            const priorityLabel = triggerPrefix === 'priority:'
+              ? triggerLabel
+              : issueLabels.find(l => l.startsWith('priority:') && PRIORITY_OPTIONS[l]);
 
             if (boardLabel) {
               try {


### PR DESCRIPTION
## Summary

- **Label transition bug:** `issueLabels.find()` searched the stale webhook payload snapshot, returning the old label instead of the trigger label during label transitions. Board column was set to the wrong value while the correct label was applied — a silent mismatch. Now uses `triggerLabel` directly when the trigger prefix matches.
- **Auto-done safety net:** New job auto-applies `board:done` when an issue is closed without it. Includes `permissions: issues: write` (required for `gh issue edit`). Chains to the sync job via the `labeled` event.

## Root Cause

Identified during DCC project audit 2026-03-21. 11 closed issues were stuck in active board columns. Applying `board:done` failed to move them because the workflow synced to the stale payload value. Same bug independently confirmed and fixed on Unfocused (PRs #796/#797).

## Test Plan

- [ ] Merge PR to main
- [ ] Post-fix test: pick a closed issue in Done, add `board:testing`, wait 10s, add `board:done`, wait 45s — confirm board column shows Done (not Testing)
- [ ] Auto-done chain test: close an open issue WITHOUT applying `board:done` — confirm `auto-done` fires, applies label, `sync` moves item to Done
- [ ] Re-apply `board:done` to the 11 orphaned issues and confirm they move to Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)