### PR TITLE
fix: board governance standardization — DifferentWire 7-column standard

### DIFF
--- a/.github/workflows/sync-labels-to-board.yml
+++ b/.github/workflows/sync-labels-to-board.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Apply board:done to closed issue
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PROJECT_PAT }}
         run: |
           labels=$(gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json labels -q '.labels[].name')
           if ! echo "$labels" | grep -q "board:done"; then
@@ -41,13 +41,13 @@ jobs:
 
             const STATUS_FIELD_ID = 'PVTSSF_lAHODGcOBc4BQ5xSzg-43pc';
             const STATUS_OPTIONS = {
-              'board:backlog':     'f75ad846',  // Backlog
-              'board:ready':       'e18bf179',  // Ready
-              'board:in-progress': '47fc9ee4',  // In progress
-              'board:testing':     'aba860b9',  // In review (closest match)
-              'board:on-hold':     '0a4cdbf4',  // Deferred (closest match)
-              'board:done':        '98236657',  // Done
-              // board:todo — no matching column on DCC board
+              'board:backlog':     'cc41e1ac',  // Backlog
+              'board:todo':        '35650882',  // Todo
+              'board:ready':       '3c1f90c0',  // Ready
+              'board:in-progress': 'e6c780ff',  // In Progress
+              'board:testing':     '2107e3a5',  // Testing
+              'board:deferred':    '659b453d',  // Deferred
+              'board:done':        '206efbce',  // Done
             };
 
             const PRIORITY_FIELD_ID = 'PVTSSF_lAHODGcOBc4BQ5xSzg-43q4';
@@ -56,6 +56,7 @@ jobs:
               'priority:P1': '0a877460',
               'priority:P2': 'da944a9c',
               'priority:P3': '22a5bedc',
+              'priority:P4': 'bb5bedf4',
             };
 
             // ── Determine what triggered us ─────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Desk Command Center — Project Guide
 
+> **Standards:** This project follows DifferentWire standards.
+> **Read and apply:** `C:\Dev\CLAUDE-BASE.md`, `C:\Dev\SAFELANE.md`
+> **Credential inventory:** `C:\Dev\.credentials.env`
+
 > **Hardware:** CrowPanel Advance 5.0" HMI (ESP32-S3-WROOM-1-N16R8)
 > **Framework:** ESP-IDF / Arduino + LVGL
 > **Toolchain:** PlatformIO (VSCode) or Arduino IDE
@@ -385,12 +389,13 @@ gh issue edit 42 --add-label "board:ready,priority:P2"
 | Label | Board Column |
 |-------|-------------|
 | `board:backlog` | Backlog |
+| `board:todo` | Todo |
 | `board:ready` | Ready |
-| `board:in-progress` | In progress |
-| `board:testing` | In review |
-| `board:on-hold` | Deferred |
+| `board:in-progress` | In Progress |
+| `board:testing` | Testing |
+| `board:deferred` | Deferred |
 | `board:done` | Done |
-| `priority:P0` through `priority:P3` | Priority field |
+| `priority:P0` through `priority:P4` | Priority field |
 
 Labels are mutually exclusive within their group — the Action auto-removes old labels.
 


### PR DESCRIPTION
## Summary

- Add DifferentWire standards references to CLAUDE.md header (CLAUDE-BASE.md, SAFELANE.md, .credentials.env)
- Update sync-labels-to-board.yml with new board column option IDs (all 7 columns recreated at board level)
- Add `board:todo` and `board:deferred` label mappings (previously missing/misnamed)
- Remove `board:on-hold` (replaced by `board:deferred`)
- Add `priority:P4` option
- Fix auto-done job to use `PROJECT_PAT` instead of `GITHUB_TOKEN` (enables chained sync triggers)
- Trigger label fix already present from PR #229

## What Changed at Board Level (already done, not in this PR)

Board columns standardized to: Backlog, Todo, Ready, In Progress, Testing, Deferred, Done

## Test Plan

- [ ] After merge, apply `board:todo` to a test issue — confirm it moves to Todo column
- [ ] Apply `board:deferred` — confirm Deferred column
- [ ] Close an issue without `board:done` — confirm auto-done chain fires (auto-done applies label via PROJECT_PAT, sync moves to Done)
- [ ] Verify `board:on-hold` label no longer exists on any issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)