### PR TITLE
feat(#237): replace BeadsAdapter with CitadelAdapter + OverwatchAdapter

### DIFF
--- a/bridge/adapters/citadel.py
+++ b/bridge/adapters/citadel.py
@@ -1,0 +1,175 @@
+"""Citadel adapter — polls task management API for project health."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from .base import AdapterConfig, BaseAdapter
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_URL = "https://getunfocused.app/citadel"
+
+
+class CitadelAdapter(BaseAdapter):
+    """Polls Citadel REST API for task status across all projects.
+
+    Config from BridgeConfig:
+      citadel.api_url: Citadel API base URL
+      citadel.projects: list of project names (auto-discovered if empty)
+      citadel.poll_interval: seconds between polls
+
+    Comprehensive polling: fetches stats (all statuses) + active tasks
+    per project. Output shape matches legacy BeadsAdapter for display
+    compatibility.
+    """
+
+    def __init__(self, source_config: dict[str, Any]) -> None:
+        poll_interval = source_config.get("poll_interval", 60)
+
+        super().__init__(
+            name="citadel",
+            config=AdapterConfig(
+                poll_interval=poll_interval,
+                ttl=poll_interval * 3,
+                max_retries=2,
+                backoff_base=5.0,
+                backoff_max=120.0,
+            ),
+        )
+        self.api_url = source_config.get("api_url", DEFAULT_API_URL).rstrip("/")
+        self.projects: list[str] = source_config.get("projects", [])
+
+    async def poll(self) -> dict[str, Any]:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            # Health check
+            health = await client.get(f"{self.api_url}/health")
+            health.raise_for_status()
+
+            # Discover projects if not configured
+            project_names = self.projects
+            if not project_names:
+                resp = await client.get(f"{self.api_url}/projects")
+                resp.raise_for_status()
+                project_names = [p["name"] for p in resp.json()]
+
+            results: dict[str, Any] = {}
+            for name in project_names:
+                try:
+                    # Stats: full status breakdown in one call
+                    stats_resp = await client.get(
+                        f"{self.api_url}/projects/{name}/stats",
+                    )
+                    stats_resp.raise_for_status()
+                    stats = stats_resp.json()
+
+                    # Active tasks: details for in_progress items
+                    tasks_resp = await client.get(
+                        f"{self.api_url}/projects/{name}/tasks",
+                        params={"status": "in_progress"},
+                    )
+                    tasks_resp.raise_for_status()
+                    tasks = tasks_resp.json()
+
+                    results[name] = {
+                        "stats": stats,
+                        "tasks": tasks,
+                    }
+                except httpx.HTTPStatusError as exc:
+                    logger.warning("Citadel: %s returned %d", name, exc.response.status_code)
+                    results[name] = {"error": str(exc)}
+                except httpx.RequestError as exc:
+                    logger.warning("Citadel: %s request failed: %s", name, exc)
+                    results[name] = {"error": str(exc)}
+
+        return {"projects": results}
+
+    def parse(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Transform raw Citadel API responses into BeadsAdapter-compatible shape.
+
+        Output:
+          {
+            "projects": {
+              "Unfocused": {
+                "status": "ok",
+                "display_name": "Unfocused",
+                "open": N,           # backlog + todo + ready
+                "in_progress": N,
+                "blocked": 0,
+                "done": N,
+                "total": N,
+                "by_status": {...},
+                "tasks": [...]
+              }
+            },
+            "total_open": N,
+            "total_in_progress": N,
+            "blocked_count": 0
+          }
+        """
+        projects: dict[str, Any] = {}
+        total_open = 0
+        total_in_progress = 0
+
+        for name, data in raw.get("projects", {}).items():
+            if "error" in data:
+                projects[name] = {
+                    "status": "error",
+                    "error": data["error"],
+                    "tasks": [],
+                }
+                continue
+
+            stats = data.get("stats", {})
+            by_status = stats.get("by_status", {})
+            tasks_raw = data.get("tasks", [])
+
+            backlog = by_status.get("backlog", 0)
+            todo = by_status.get("todo", 0)
+            ready = by_status.get("ready", 0)
+            in_progress = by_status.get("in_progress", 0)
+            testing = by_status.get("testing", 0)
+            done = by_status.get("done", 0)
+            deferred = by_status.get("deferred", 0)
+
+            # "open" = actionable work not yet done
+            open_count = backlog + todo + ready + testing
+
+            tasks = [
+                {
+                    "id": t.get("short_id", ""),
+                    "title": t.get("title", ""),
+                    "status": t.get("status", ""),
+                    "priority": t.get("priority"),
+                    "assignee": t.get("assignee"),
+                    "external_ref": t.get("external_issue_number"),
+                    "type": t.get("issue_type", "task"),
+                }
+                for t in tasks_raw
+            ]
+
+            total_open += open_count
+            total_in_progress += in_progress
+
+            projects[name] = {
+                "status": "ok",
+                "display_name": name,
+                "open": open_count,
+                "in_progress": in_progress,
+                "blocked": 0,
+                "done": done,
+                "deferred": deferred,
+                "total": stats.get("total", 0),
+                "by_status": by_status,
+                "tasks": tasks,
+            }
+
+        return {
+            "projects": projects,
+            "total_open": total_open,
+            "total_in_progress": total_in_progress,
+            "blocked_count": 0,
+        }

--- a/bridge/adapters/overwatch.py
+++ b/bridge/adapters/overwatch.py
@@ -1,0 +1,133 @@
+"""Overwatch adapter — polls compliance audit reports from Overwatch API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from .base import AdapterConfig, BaseAdapter
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_URL = "https://getunfocused.app/overwatch"
+
+
+class OverwatchAdapter(BaseAdapter):
+    """Polls Overwatch compliance report endpoint.
+
+    Config from BridgeConfig:
+      overwatch.api_url: Overwatch API base URL
+      overwatch.poll_interval: seconds between polls (default 300)
+
+    Returns structured compliance findings with pass/warn/fail counts
+    and per-project breakdowns.
+    """
+
+    def __init__(self, source_config: dict[str, Any]) -> None:
+        poll_interval = source_config.get("poll_interval", 300)
+
+        super().__init__(
+            name="overwatch",
+            config=AdapterConfig(
+                poll_interval=poll_interval,
+                ttl=poll_interval * 3,
+                max_retries=2,
+                backoff_base=10.0,
+                backoff_max=120.0,
+            ),
+        )
+        self.api_url = source_config.get("api_url", DEFAULT_API_URL).rstrip("/")
+
+    async def poll(self) -> dict[str, Any]:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            health = await client.get(f"{self.api_url}/health")
+            health.raise_for_status()
+
+            report = await client.get(f"{self.api_url}/report")
+            report.raise_for_status()
+            return report.json()
+
+    def parse(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Transform Overwatch report JSON into display-ready structure.
+
+        Output:
+          {
+            "timestamp": "2026-04-02 05:07:00Z",
+            "counts": {"pass": 19, "warn": 21, "fail": 10},
+            "findings": [...],           # all findings
+            "failures": [...],           # severity=fail only
+            "warnings": [...],           # severity=warn only
+            "by_project": {
+              "Unfocused": {"pass": N, "warn": N, "fail": N, "findings": [...]},
+              ...
+            }
+          }
+        """
+        findings = raw.get("findings", [])
+        counts = raw.get("counts", {"pass": 0, "warn": 0, "fail": 0})
+
+        failures = [f for f in findings if f.get("severity") == "fail"]
+        warnings = [f for f in findings if f.get("severity") == "warn"]
+
+        # Build per-project breakdown
+        by_project: dict[str, dict[str, Any]] = {}
+        for finding in findings:
+            # Extract project name from summary (e.g., "Rossum: missing hooks...")
+            summary = finding.get("summary", "")
+            project = _extract_project(summary)
+            if project not in by_project:
+                by_project[project] = {
+                    "pass": 0,
+                    "warn": 0,
+                    "fail": 0,
+                    "findings": [],
+                }
+            severity = finding.get("severity", "pass")
+            if severity in by_project[project]:
+                by_project[project][severity] += 1
+            by_project[project]["findings"].append(finding)
+
+        return {
+            "timestamp": raw.get("timestamp", ""),
+            "counts": counts,
+            "findings": findings,
+            "failures": failures,
+            "warnings": warnings,
+            "by_project": by_project,
+        }
+
+
+def _extract_project(summary: str) -> str:
+    """Best-effort project name extraction from finding summary.
+
+    Patterns:
+      "Rossum: missing hooks..."        → "Rossum"
+      "Rossum PR #54 stale..."          → "Rossum"
+      "Rossum-4rk claimed 192h ago..."  → "Rossum"
+      "Citadel API: 200 (9ms)"         → "Infrastructure"
+      "Agent Mail: alive"               → "Infrastructure"
+    """
+    # Known infrastructure keywords that aren't project names
+    infra_prefixes = ("Citadel API", "Agent Mail", "Gemini reviewer", "Postgres disk")
+    for prefix in infra_prefixes:
+        if summary.startswith(prefix):
+            return "Infrastructure"
+
+    # "ProjectName: ..." or "ProjectName-xxx ..." patterns
+    if ": " in summary:
+        candidate = summary.split(":")[0].strip()
+        # Filter out short IDs like "Rossum-4rk"
+        if "-" in candidate:
+            candidate = candidate.split("-")[0]
+        if candidate and candidate[0].isupper():
+            return candidate
+
+    # "ProjectName PR #N" or "ProjectName #N"
+    for token in summary.split():
+        if token and token[0].isupper() and token.isalnum():
+            return token
+        break
+
+    return "Other"

--- a/bridge/config.py
+++ b/bridge/config.py
@@ -27,7 +27,7 @@ SECRET_KEYS = re.compile(
 
 # Source keys that are per-user in multi-user mode
 _PER_USER_SOURCES = {
-    "weather", "google_calendar", "github", "beads",
+    "weather", "google_calendar", "github", "citadel", "overwatch",
     "unfocused_tasks", "claude", "claude_status", "devops", "monday",
 }
 

--- a/bridge/main.py
+++ b/bridge/main.py
@@ -26,14 +26,24 @@ from fastapi.responses import JSONResponse
 
 from adapters import TTLCache, AdapterScheduler
 from adapters.base import BaseAdapter
-from adapters.beads import BeadsAdapter
-from adapters.claude_status import ClaudeStatusAdapter
+from adapters.citadel import CitadelAdapter
+from adapters.overwatch import OverwatchAdapter
 from adapters.github import GitHubAdapter
-from adapters.monday import MondayAdapter
 from adapters.google_calendar import GoogleCalendarAdapter
 from adapters.home_assistant import HomeAssistantAdapter
 from adapters.unfocused_tasks import UnfocusedTasksAdapter
 from adapters.weather import WeatherAdapter
+
+# Optional adapters — may not be deployed on all hosts
+try:
+    from adapters.claude_status import ClaudeStatusAdapter
+except ImportError:
+    ClaudeStatusAdapter = None  # type: ignore[assignment,misc]
+
+try:
+    from adapters.monday import MondayAdapter
+except ImportError:
+    MondayAdapter = None  # type: ignore[assignment,misc]
 from config import BridgeConfig
 from push_store import PushStore
 
@@ -46,12 +56,16 @@ ADAPTER_CLASSES: dict[str, type[BaseAdapter]] = {
     "weather": WeatherAdapter,
     "github": GitHubAdapter,
     "google_calendar": GoogleCalendarAdapter,
-    "beads": BeadsAdapter,
+    "citadel": CitadelAdapter,
+    "overwatch": OverwatchAdapter,
     "unfocused_tasks": UnfocusedTasksAdapter,
     "home_assistant": HomeAssistantAdapter,
-    "claude_status": ClaudeStatusAdapter,
-    "monday": MondayAdapter,
 }
+
+if ClaudeStatusAdapter is not None:
+    ADAPTER_CLASSES["claude_status"] = ClaudeStatusAdapter
+if MondayAdapter is not None:
+    ADAPTER_CLASSES["monday"] = MondayAdapter
 
 
 def create_adapter(

--- a/bridge/tests/test_multi_user.py
+++ b/bridge/tests/test_multi_user.py
@@ -98,8 +98,11 @@ class TestAdapterFactory:
             create_adapter("nonexistent", {})
 
     def test_all_adapter_classes_registered(self):
-        expected = {"weather", "github", "google_calendar", "beads", "unfocused_tasks", "home_assistant", "claude_status", "monday"}
-        assert set(ADAPTER_CLASSES.keys()) == expected
+        required = {"weather", "github", "google_calendar", "citadel", "overwatch", "unfocused_tasks", "home_assistant"}
+        optional = {"claude_status", "monday"}  # conditional imports
+        actual = set(ADAPTER_CLASSES.keys())
+        assert required <= actual, f"Missing required adapters: {required - actual}"
+        assert actual <= required | optional, f"Unexpected adapters: {actual - required - optional}"
 
     def test_shared_adapter_no_user_scope(self):
         adapter = create_adapter("home_assistant", {"url": "http://ha:8123"})


### PR DESCRIPTION
## Summary
- **CitadelAdapter** — polls Citadel REST API for task status across 6 projects (comprehensive: stats + active tasks, ~12 calls per 60s cycle)
- **OverwatchAdapter** — polls Overwatch JSON endpoint for compliance audit findings (pass/warn/fail counts, per-project breakdowns)
- Removed dead BeadsAdapter (Dolt/MySQL) from adapter registry and config
- Made claude_status and monday adapter imports optional (not deployed on Pi)
- Bridge config updated on Pi, deployed, verified — both adapters returning `status: ok`

Closes #237

## Test plan
- [x] CitadelAdapter polls all 6 projects, returns BeadsAdapter-compatible output shape
- [x] OverwatchAdapter parses Overwatch report JSON into structured findings
- [x] Bridge builds and starts without import errors
- [x] `GET /api/adapters` shows `citadel:strycher ok` and `overwatch:strycher ok`
- [x] `GET /api/dashboard` returns full Citadel data (104 open, 7 in_progress) and Overwatch data (19 pass, 21 warn, 10 fail)
- [x] No regression on other adapters (github, weather, unfocused_tasks, home_assistant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)