### PR TITLE
sec(#252): move secrets out of bridge_config.json into .env

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,15 +278,46 @@ Implement a resource mutex if both features are needed.
 
 **NEVER use password auth.** NEVER guess the username. It is `strycher`. Always.
 
+### Secrets Hygiene (CRITICAL — read before touching bridge files)
+
+The bridge's secret material lives in **`bridge/.env`**, NOT in
+`bridge_config.json`. The JSON file holds non-secret structure with
+`${ENV:VAR_NAME}` placeholders; the runtime resolves them from environment
+variables loaded by Docker Compose's `env_file` directive.
+
+**Files and what they contain:**
+
+| File | Contains | Safe to read/echo? |
+|------|----------|---------------------|
+| `bridge/bridge_config.json` (local + Pi) | Structure with `${ENV:...}` placeholders only | YES — no secrets in plaintext |
+| `bridge/.env` (Pi only, gitignored) | Real API keys, OAuth tokens, refresh tokens, PATs | **NO — never echo, paste, or include in agent output** |
+
+**Hard rules for any agent or human editing bridge files:**
+- **NEVER** include `.env` contents in any output, log, commit message, PR
+  body, summary, or response. The filename is the universal "do not expose"
+  signal — respect it.
+- **NEVER** paste resolved secret values back into `bridge_config.json`.
+  If you see an actual token there instead of `${ENV:...}`, that's a
+  regression — fix it, do not commit it.
+- The migration script `bridge/migrate_secrets_to_env.py` is one-shot and
+  idempotent. Re-running on a clean (post-migration) config is a no-op.
+
 ### Bridge Config Updates (CRITICAL)
 
-`bridge_config.json` on the Pi contains secrets (API keys, tokens) that do NOT
-exist in the local repo copy. **NEVER SCP the full file to the Pi.**
+`bridge_config.json` on the Pi contains the canonical structure with placeholders
+for secrets. The local repo copy (`bridge/bridge_config.json`) lags. **NEVER SCP
+the full file to the Pi** — it would clobber the placeholders the Pi's adapters
+depend on.
 
-**Safe update process:**
+**Updating secrets (rotated tokens, new credentials):**
+- Edit `bridge/.env` on the Pi directly, OR
+- Append/overwrite a single line: `KEY=new-value`
+- Restart container: `docker restart dcc-bridge`
+
+**Updating non-secret structure (poll intervals, project lists, device entries):**
 ```bash
 # Update individual fields via the merge script:
-ssh strycher@192.168.50.24 'echo '"'"'{"google_calendar": {"refresh_token": "NEW"}}'"'"' | /home/strycher/dcc-bridge/update_config.sh'
+ssh strycher@192.168.50.24 'echo '"'"'{"display": {"poll_interval": 60}}'"'"' | /home/strycher/dcc-bridge/update_config.sh'
 
 # Show backups:
 ssh strycher@192.168.50.24 '/home/strycher/dcc-bridge/update_config.sh --show-backups'
@@ -296,10 +327,10 @@ ssh strycher@192.168.50.24 '/home/strycher/dcc-bridge/update_config.sh --restore
 ```
 
 **Rules:**
-- `update_config.sh` deep-merges patches — unmentioned keys are preserved
+- `update_config.sh` deep-merges JSON patches — unmentioned keys are preserved
 - Automatic backup before every write (10 rotations kept)
-- **NEVER** run `scp bridge_config.json strycher@...` — it overwrites secrets
-- After config update: `docker restart dcc-bridge`
+- **NEVER** run `scp bridge_config.json strycher@...` — it overwrites placeholders
+- After any config update: `docker restart dcc-bridge`
 
 ---
 

--- a/bridge/config.py
+++ b/bridge/config.py
@@ -8,12 +8,24 @@ Supports two config schemas:
 - **Multi-user (nested):** users/devices/shared_sources structure
 
 Legacy configs are auto-migrated to the nested schema on load.
+
+## Secrets handling (issue #252)
+
+Secrets live in `.env` (universally-recognized "do not expose" filename),
+not in bridge_config.json. The on-disk JSON contains placeholders:
+    "refresh_token": "${ENV:USERS_STRYCHER_GOOGLE_CALENDAR_REFRESH_TOKEN}"
+
+At load time, placeholders are substituted from os.environ to produce the
+runtime config. The on-disk copy (`self._raw`) keeps placeholders intact;
+mutations write back the placeholder version, so secrets never leak into
+bridge_config.json. The resolved copy (`self._data`) is what adapters see.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -24,6 +36,35 @@ logger = logging.getLogger(__name__)
 SECRET_KEYS = re.compile(
     r"(api_key|secret|token|password|credential)", re.IGNORECASE,
 )
+
+# ${ENV:VAR_NAME} placeholder for env-resolved secrets
+_ENV_PLACEHOLDER_RE = re.compile(r"\$\{ENV:([A-Z0-9_]+)\}")
+
+
+def _resolve_env_placeholders(value: Any) -> Any:
+    """Recursively replace ${ENV:VAR} placeholders with os.environ values.
+
+    Returns a deep copy of `value` with placeholders substituted in any
+    string fields. Missing env vars resolve to empty string (a warning is
+    logged once per missing var). Non-string scalars and unrecognised
+    structures pass through unchanged.
+    """
+    if isinstance(value, str):
+        def _sub(match: re.Match) -> str:
+            var = match.group(1)
+            resolved = os.environ.get(var)
+            if resolved is None:
+                logger.warning(
+                    "Config references env var %s but it is not set", var,
+                )
+                return ""
+            return resolved
+        return _ENV_PLACEHOLDER_RE.sub(_sub, value)
+    if isinstance(value, dict):
+        return {k: _resolve_env_placeholders(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve_env_placeholders(x) for x in value]
+    return value
 
 # Source keys that are per-user in multi-user mode
 _PER_USER_SOURCES = {
@@ -115,6 +156,11 @@ class BridgeConfig:
 
     def __init__(self, path: Path | None = None) -> None:
         self._path = path or CONFIG_PATH
+        # _raw is what's persisted to disk (with ${ENV:VAR} placeholders).
+        # _data is the runtime view with placeholders resolved against env.
+        # Mutations write _raw and re-derive _data; _save() never writes
+        # resolved secrets back to disk.
+        self._raw: dict[str, Any] = {}
         self._data: dict[str, Any] = {}
         self._load()
 
@@ -123,25 +169,30 @@ class BridgeConfig:
         """True if config uses the nested multi-user schema."""
         return _is_nested_schema(self._data)
 
+    def _refresh_runtime(self) -> None:
+        """Re-derive `self._data` from `self._raw` by resolving env placeholders."""
+        self._data = _resolve_env_placeholders(self._raw)
+
     def _load(self) -> None:
         """Load from disk, migrating legacy format if needed."""
         if self._path.exists():
             try:
                 raw = json.loads(self._path.read_text())
-                if _is_nested_schema(raw):
-                    self._data = raw
-                else:
-                    self._data = _migrate_flat_to_nested(raw)
+                if not _is_nested_schema(raw):
+                    raw = _migrate_flat_to_nested(raw)
+                self._raw = raw
+                self._refresh_runtime()
                 logger.info("Config loaded from %s", self._path)
                 return
             except (json.JSONDecodeError, OSError) as exc:
                 logger.warning("Failed to load config (%s), using defaults", exc)
-        self._data = json.loads(json.dumps(DEFAULT_CONFIG))  # deep copy
+        self._raw = json.loads(json.dumps(DEFAULT_CONFIG))  # deep copy
+        self._refresh_runtime()
 
     def _save(self) -> None:
-        """Persist current config to disk."""
+        """Persist `self._raw` to disk (placeholders preserved, never resolved secrets)."""
         try:
-            self._path.write_text(json.dumps(self._data, indent=2))
+            self._path.write_text(json.dumps(self._raw, indent=2))
         except OSError as exc:
             logger.error("Failed to save config: %s", exc)
 
@@ -196,11 +247,12 @@ class BridgeConfig:
     ) -> None:
         """Record an unknown device in unregistered_devices."""
         from datetime import datetime, timezone
-        unreg = self._data.setdefault("unregistered_devices", {})
+        unreg = self._raw.setdefault("unregistered_devices", {})
         unreg[chip_id] = {
             "first_seen": datetime.now(timezone.utc).isoformat(),
             "source_ip": source_ip,
         }
+        self._refresh_runtime()
         self._save()
         logger.warning("Unknown device %s from %s", chip_id, source_ip)
 
@@ -242,20 +294,23 @@ class BridgeConfig:
                     f"Section {section!r} cannot be updated via REST API"
                 )
                 continue
-            if section not in self._data:
+            if section not in self._raw:
                 errors.append(f"Unknown section: {section!r}")
                 continue
             if not isinstance(values, dict):
                 errors.append(f"Section {section!r} must be an object")
                 continue
 
-            target = self._data[section]
+            # Mutate _raw (placeholders preserved). Use _data for type-checking
+            # since _raw may contain ${ENV:...} strings instead of resolved values.
+            raw_target = self._raw[section]
+            data_target = self._data.get(section, {})
             for key, value in values.items():
-                if key not in target:
+                if key not in raw_target:
                     errors.append(f"Unknown key: {section}.{key}")
                     continue
 
-                expected_type = type(target[key])
+                expected_type = type(data_target.get(key)) if data_target.get(key) is not None else type(raw_target[key])
                 if expected_type is not type(None) and not isinstance(value, expected_type):
                     if isinstance(value, (int, float)) and expected_type in (int, float):
                         value = expected_type(value)
@@ -267,10 +322,11 @@ class BridgeConfig:
                         )
                         continue
 
-                target[key] = value
+                raw_target[key] = value
                 updated.append(f"{section}.{key}")
 
         if updated:
+            self._refresh_runtime()
             self._save()
             logger.info("Config updated: %s", ", ".join(updated))
 

--- a/bridge/docker-compose.yml
+++ b/bridge/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       - "8080:8080"
     networks:
       - dcc-net
+    # Secrets live in .env and are injected as environment variables.
+    # bridge_config.json references them via ${ENV:VAR} placeholders. See
+    # docs/bridge-secrets.md and issue #252.
+    env_file:
+      - .env
     volumes:
       - ./bridge_config.json:/app/bridge_config.json
       - ./data:/app/data

--- a/bridge/migrate_secrets_to_env.py
+++ b/bridge/migrate_secrets_to_env.py
@@ -1,0 +1,156 @@
+"""One-shot migration: extract plaintext secrets from bridge_config.json
+into a sibling .env file, replacing in-place values with ${ENV:VAR}
+placeholders (issue #252).
+
+Run on the Pi where bridge_config.json contains real credentials:
+    python migrate_secrets_to_env.py /home/strycher/dcc-bridge
+
+The script:
+  1. Backs up bridge_config.json with a timestamp suffix
+  2. Walks the config tree, identifying values whose KEY matches the
+     SECRET_KEYS pattern (api_key, secret, token, password, credential)
+  3. Mints an env var name from the path (e.g. users.strycher.sources.github
+     .api_key -> USERS_STRYCHER_GITHUB_API_KEY)
+  4. Writes KEY=VALUE pairs to .env (preserving any existing entries that
+     don't conflict)
+  5. Replaces the in-place value with "${ENV:KEY}" in bridge_config.json
+  6. Writes both files
+
+Idempotent: re-running will skip values that are already placeholders.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+SECRET_KEYS = re.compile(
+    r"(api_key|secret|token|password|credential)", re.IGNORECASE,
+)
+PLACEHOLDER_RE = re.compile(r"^\$\{ENV:[A-Z0-9_]+\}$")
+SOURCES_TOKEN = "sources"  # strip from path-based names for brevity
+
+
+def _path_to_env_name(path: list[str]) -> str:
+    """Convert a config path to a safe env-var name.
+
+    e.g. ['users', 'strycher', 'sources', 'github', 'api_key']
+         -> 'USERS_STRYCHER_GITHUB_API_KEY'
+    """
+    parts = [p for p in path if p != SOURCES_TOKEN]
+    name = "_".join(parts).upper()
+    name = re.sub(r"[^A-Z0-9_]", "_", name)
+    return name
+
+
+def _walk_and_extract(
+    node: Any, path: list[str], extracted: dict[str, str],
+) -> Any:
+    """Recursively walk node. Replace secret-key values with ${ENV:VAR}
+    placeholders and record (env_name, value) pairs in `extracted`.
+
+    Skips already-placeholder values. Returns the (possibly modified)
+    node — caller must reassign for in-place semantics.
+    """
+    if isinstance(node, dict):
+        for key, value in list(node.items()):
+            sub_path = path + [key]
+            if isinstance(value, str) and SECRET_KEYS.search(key):
+                if not value:
+                    continue  # empty string — nothing to extract
+                if PLACEHOLDER_RE.match(value):
+                    continue  # already migrated
+                env_name = _path_to_env_name(sub_path)
+                if env_name in extracted and extracted[env_name] != value:
+                    raise ValueError(
+                        f"Env var name collision: {env_name} maps to two "
+                        f"different values"
+                    )
+                extracted[env_name] = value
+                node[key] = "${ENV:" + env_name + "}"
+            else:
+                node[key] = _walk_and_extract(value, sub_path, extracted)
+        return node
+    if isinstance(node, list):
+        return [_walk_and_extract(x, path, extracted) for x in node]
+    return node
+
+
+def _write_env_file(env_path: Path, new_entries: dict[str, str]) -> None:
+    """Append new entries to .env, preserving existing entries that don't
+    conflict. Each entry written as KEY=VALUE on its own line."""
+    existing: dict[str, str] = {}
+    if env_path.exists():
+        for raw in env_path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                k, v = line.split("=", 1)
+                existing[k.strip()] = v
+    # Merge — new wins on conflict (the migration is the source of truth)
+    merged = {**existing, **new_entries}
+    lines = ["# bridge secrets — referenced by bridge_config.json via ${ENV:VAR}",
+             "# DO NOT include this file's contents in any output. Gitignored.",
+             ""]
+    for key in sorted(merged):
+        lines.append(f"{key}={merged[key]}")
+    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: python migrate_secrets_to_env.py <bridge_dir>", file=sys.stderr)
+        return 2
+
+    bridge_dir = Path(sys.argv[1])
+    cfg_path = bridge_dir / "bridge_config.json"
+    env_path = bridge_dir / ".env"
+
+    if not cfg_path.exists():
+        print(f"Config not found: {cfg_path}", file=sys.stderr)
+        return 1
+
+    # Backup
+    backup_dir = bridge_dir / "config_backups"
+    backup_dir.mkdir(exist_ok=True)
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    backup = backup_dir / f"bridge_config.{ts}.pre-env-migration.json"
+    shutil.copy(cfg_path, backup)
+    print(f"Backed up config to: {backup}")
+
+    # Load, extract, rewrite
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+    extracted: dict[str, str] = {}
+    cfg = _walk_and_extract(cfg, [], extracted)
+
+    if not extracted:
+        print("No new secrets to migrate (all already placeholders or empty).")
+        return 0
+
+    print(f"Extracted {len(extracted)} secrets:")
+    for k in sorted(extracted):
+        masked = extracted[k][:6] + "…" if len(extracted[k]) > 6 else "***"
+        print(f"  {k}={masked}")
+
+    _write_env_file(env_path, extracted)
+    print(f"Wrote secrets to: {env_path}")
+
+    cfg_path.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    print(f"Updated config (placeholders only) at: {cfg_path}")
+
+    print("\nNext steps:")
+    print("  1. Verify .env is gitignored")
+    print("  2. Add 'env_file: .env' to docker-compose.yml bridge service")
+    print("  3. cd into bridge dir, restart container: docker compose up -d bridge")
+    print("  4. Verify all adapters show 'ok' in /api/adapters")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bridge/tests/test_config.py
+++ b/bridge/tests/test_config.py
@@ -329,3 +329,82 @@ def test_put_config_invalid_section():
     resp = client.put("/api/config", json={"users": {"strycher": {}}})
     assert resp.status_code == 400
     assert resp.json()["errors"]
+
+
+# --- Env-placeholder resolution (issue #252) ---
+
+import os
+from config import _resolve_env_placeholders
+
+
+class TestEnvPlaceholders:
+    def test_resolves_string_placeholder(self, monkeypatch):
+        monkeypatch.setenv("DCC_TEST_TOKEN", "actual-secret-value")
+        assert _resolve_env_placeholders("${ENV:DCC_TEST_TOKEN}") == "actual-secret-value"
+
+    def test_missing_env_resolves_to_empty(self, monkeypatch):
+        monkeypatch.delenv("DCC_NEVER_SET_VAR", raising=False)
+        assert _resolve_env_placeholders("${ENV:DCC_NEVER_SET_VAR}") == ""
+
+    def test_partial_substitution_in_string(self, monkeypatch):
+        monkeypatch.setenv("DCC_TEST_HOST", "example.com")
+        result = _resolve_env_placeholders("https://${ENV:DCC_TEST_HOST}/api")
+        assert result == "https://example.com/api"
+
+    def test_recursive_dict(self, monkeypatch):
+        monkeypatch.setenv("DCC_TEST_SECRET", "abc123")
+        node = {"users": {"strycher": {"sources": {"github": {"api_key": "${ENV:DCC_TEST_SECRET}"}}}}}
+        out = _resolve_env_placeholders(node)
+        assert out["users"]["strycher"]["sources"]["github"]["api_key"] == "abc123"
+
+    def test_non_secret_strings_pass_through(self):
+        node = {"poll_interval": 60, "url": "http://localhost:8080", "calendars": ["primary"]}
+        out = _resolve_env_placeholders(node)
+        assert out == node
+
+    def test_save_does_not_persist_resolved_secrets(self, tmp_path, monkeypatch):
+        """Critical: mutations + _save() must write placeholders, not resolved values."""
+        monkeypatch.setenv("DCC_HA_TOKEN", "real-ha-token-do-not-leak")
+        cfg_path = tmp_path / "test.json"
+        cfg_path.write_text(json.dumps({
+            "bridge": {"push_ttl": 600},
+            "display": {"poll_interval": 30, "timezone": "America/New_York"},
+            "shared_sources": {
+                "home_assistant": {
+                    "url": "http://localhost:8123",
+                    "api_key": "${ENV:DCC_HA_TOKEN}",
+                    "poll_interval": 60,
+                },
+            },
+            "users": {}, "devices": {}, "unregistered_devices": {},
+        }))
+        cfg = BridgeConfig(path=cfg_path)
+        # Runtime view sees resolved secret
+        assert cfg.get_shared_sources()["home_assistant"]["api_key"] == "real-ha-token-do-not-leak"
+        # Mutate something else and save
+        cfg.update({"bridge": {"push_ttl": 300}})
+        # On-disk file must still have the placeholder, not the resolved secret
+        on_disk = json.loads(cfg_path.read_text())
+        assert on_disk["shared_sources"]["home_assistant"]["api_key"] == "${ENV:DCC_HA_TOKEN}"
+        assert "real-ha-token-do-not-leak" not in cfg_path.read_text()
+
+    def test_record_unregistered_device_preserves_placeholders(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DCC_HA_TOKEN", "another-secret")
+        cfg_path = tmp_path / "test.json"
+        cfg_path.write_text(json.dumps({
+            "bridge": {"push_ttl": 600},
+            "display": {"poll_interval": 30, "timezone": "America/New_York"},
+            "shared_sources": {
+                "home_assistant": {
+                    "url": "http://localhost:8123",
+                    "api_key": "${ENV:DCC_HA_TOKEN}",
+                    "poll_interval": 60,
+                },
+            },
+            "users": {}, "devices": {}, "unregistered_devices": {},
+        }))
+        cfg = BridgeConfig(path=cfg_path)
+        cfg.record_unregistered_device("DEADBEEF", "192.168.1.99")
+        on_disk = json.loads(cfg_path.read_text())
+        assert on_disk["shared_sources"]["home_assistant"]["api_key"] == "${ENV:DCC_HA_TOKEN}"
+        assert "DEADBEEF" in on_disk["unregistered_devices"]

--- a/bridge/tests/test_health.py
+++ b/bridge/tests/test_health.py
@@ -143,6 +143,9 @@ def _mock_config(tmp_path=None):
     from pathlib import Path
     import tempfile
     cfg = BridgeConfig.__new__(BridgeConfig)
+    # _raw and _data are kept in sync (no env placeholders in test fixture);
+    # writes go through _raw, runtime reads from _data. See issue #252.
+    cfg._raw = json.loads(json.dumps(MULTI_USER_CONFIG))
     cfg._data = json.loads(json.dumps(MULTI_USER_CONFIG))
     # Use a temp file so _save() works for record_unregistered_device
     cfg._path = Path(tempfile.mktemp(suffix=".json"))


### PR DESCRIPTION
## Summary
- `bridge_config.json` no longer contains plaintext secrets — only `${ENV:VARNAME}` placeholders
- Real credentials live in `bridge/.env` (gitignored, loaded by Docker via `env_file:` directive)
- `BridgeConfig` uses dual state (`_raw` persisted with placeholders, `_data` resolved at runtime) so mutations cannot leak resolved secrets back to disk
- One-shot idempotent migration script extracts existing secrets and rewrites the config in place
- 7 new unit tests cover env resolution + the critical "save never persists resolved secrets" invariant
- CLAUDE.md gains a **Secrets Hygiene** section naming both files and the rules for editing each

Closes #252

## Why
Another Claude session recently read `bridge_config.json` and didn't realise the JSON contained API keys, OAuth tokens, and PATs in plaintext. Filename gave no signal. `.env` is the universal "do not expose" file pattern — every linter, CI scanner, IDE, and agent training set treats it accordingly.

## Test plan
- [x] `pytest bridge/tests/test_config.py` — 38 tests pass (31 existing + 7 new)
- [x] Migration script ran on Pi: 11 secrets extracted, `bridge_config.json` contains zero plaintext secret values
- [x] Bridge container rebuilt + restarted with new `env_file: .env`
- [x] All 10 adapters poll successfully (`/api/adapters` shows `ok` for github, weather, google_calendar, unfocused_tasks, citadel, overwatch, home_assistant — both strycher and wife users)
- [x] Backup of pre-migration config preserved at `config_backups/bridge_config.20260510_021643.pre-env-migration.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)