### PR TITLE
feat(#255): expand DCC repo + Citadel project lists with scrolling

### DIFF
--- a/firmware/include/dashboard_data.h
+++ b/firmware/include/dashboard_data.h
@@ -9,7 +9,7 @@
 
 static constexpr uint8_t MAX_EVENTS = 20;
 static constexpr uint8_t MAX_TASKS  = 20;
-static constexpr uint8_t MAX_REPOS  = 10;
+static constexpr uint8_t MAX_REPOS  = 32;
 static constexpr uint8_t MAX_HA_ENTITIES = 40;
 static constexpr uint8_t MAX_HA_PER_DOMAIN = 6;
 static constexpr uint8_t MAX_HA_DEVICES = MAX_HA_ENTITIES;  // each device has ≥1 entity
@@ -65,7 +65,7 @@ struct WeatherData {
     uint8_t daily_count;
 };
 
-static constexpr uint8_t MAX_BEADS_PROJECTS = 6;
+static constexpr uint8_t MAX_BEADS_PROJECTS = 32;
 static constexpr uint8_t MAX_CI_RUNS = 5;
 
 struct BeadsProject {

--- a/firmware/src/ui/screens/devops_screen.cpp
+++ b/firmware/src/ui/screens/devops_screen.cpp
@@ -69,6 +69,9 @@ void DevOpsScreen::create(lv_obj_t* parent) {
     lv_obj_set_style_pad_all(_repoList, 0, 0);
     lv_obj_set_style_pad_row(_repoList, SU(6), 0);
     lv_obj_set_flex_flow(_repoList, LV_FLEX_FLOW_COLUMN);
+    /* Touch-scroll vertically; scrollbar shown only when content overflows. */
+    lv_obj_set_scrollbar_mode(_repoList, LV_SCROLLBAR_MODE_AUTO);
+    lv_obj_set_scroll_dir(_repoList, LV_DIR_VER);
 
     /* === Right: Citadel per-project card === */
     lv_obj_t* citadelCard = makeCard(_screen, SX(500), UI_CONTENT_Y + UI_PAD,
@@ -81,14 +84,20 @@ void DevOpsScreen::create(lv_obj_t* parent) {
     lv_obj_align(citadelHeader, LV_ALIGN_TOP_LEFT, 0, 0);
 
     _beadsContainer = lv_obj_create(citadelCard);
-    lv_obj_set_size(_beadsContainer, SX(266), LV_SIZE_CONTENT);
+    /* Fixed height so the container scrolls when project count exceeds
+       what fits in the card.  Card is SY(220), header occupies SY(22),
+       card padding is SU(12) on each side — available is roughly SY(174). */
+    lv_obj_set_size(_beadsContainer, SX(266), SY(174));
     lv_obj_align(_beadsContainer, LV_ALIGN_TOP_LEFT, 0, SY(22));
     lv_obj_set_style_bg_opa(_beadsContainer, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(_beadsContainer, 0, 0);
     lv_obj_set_style_pad_all(_beadsContainer, 0, 0);
     lv_obj_set_style_pad_row(_beadsContainer, SU(4), 0);
     lv_obj_set_flex_flow(_beadsContainer, LV_FLEX_FLOW_COLUMN);
-    lv_obj_clear_flag(_beadsContainer, LV_OBJ_FLAG_SCROLLABLE);
+    /* Enable touch scrolling; scrollbar auto-hides when content fits. */
+    lv_obj_add_flag(_beadsContainer, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_scrollbar_mode(_beadsContainer, LV_SCROLLBAR_MODE_AUTO);
+    lv_obj_set_scroll_dir(_beadsContainer, LV_DIR_VER);
 
     /* === Right: Agent status card === */
     lv_obj_t* agentCard = makeCard(_screen, SX(500), UI_CONTENT_Y + SY(240),


### PR DESCRIPTION
## Summary
Firmware:
- \`MAX_REPOS\`: 10 → 32 (room for current 10 + headroom)
- \`MAX_BEADS_PROJECTS\`: 6 → 32 (was hard-blocking at 6)
- \`_beadsContainer\` (Citadel widget): restored to fixed-height scrollable container with \`LV_SCROLLBAR_MODE_AUTO\` + \`LV_DIR_VER\`
- \`_repoList\`: explicit scrollbar mode + vertical scroll direction

Bridge (deployed on Pi separately via \`update_config.sh\`, no code in this PR):
- 10 GitHub repos: DCC, Field_Compass, LoRa, Unfocused, Rossum, Unfound, standards, citadel, Overwatch, Home_Assistant
- Citadel \`projects: []\` enables adapter auto-discovery (12 projects)

Closes #255

## Verification
- [x] \`pio run -e crowpanel5\`: clean
- [x] \`pio run -e crowpanel7\`: clean
- [x] dcc-panel7 flashed: 10 repos visible, 12 Citadel projects visible, touch-scroll works
- [ ] dcc-desk visual verification: deferred (device currently disconnected)
- [x] Bridge \`/api/dashboard\` returns all 10 repos status=ok, 12 projects auto-discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)