### PR TITLE
epic(#260): home screen multi-timezone display (local + AZ + PT)

### DIFF
--- a/firmware/include/time_helpers.h
+++ b/firmware/include/time_helpers.h
@@ -1,0 +1,37 @@
+/**
+ * Time Helpers — multi-timezone formatting (issue #257).
+ *
+ * Used by the home screen to display Arizona / Pacific time alongside
+ * the local (Eastern) clock without disturbing the process-wide TZ
+ * setting that NtpTime owns.
+ *
+ * Single-thread use only (LVGL UI thread). setenv/tzset is not
+ * thread-safe; callers must not invoke this concurrently with other
+ * code that reads localtime.
+ */
+
+#pragma once
+#include <stddef.h>
+#include <time.h>
+
+namespace TimeHelpers {
+    /**
+     * Format the current wall-clock time in the given POSIX TZ string,
+     * as 12-hour "H:MM AM/PM" (matches NtpTime::timeStr style — no
+     * leading zero on hour).
+     *
+     * Temporarily switches the process TZ, formats, then restores the
+     * previous TZ. If the system clock is not yet synced (epoch ~1970),
+     * the formatter still produces a value — caller is expected to
+     * gate display via NtpTime::isSynced().
+     *
+     * @param posixTz POSIX TZ string, e.g. "MST7", "PST8PDT,M3.2.0,M11.1.0"
+     * @param outBuf  caller-allocated buffer
+     * @param bufLen  size of outBuf (recommend >= 12 bytes)
+     */
+    void formatNow12h(const char* posixTz, char* outBuf, size_t bufLen);
+
+    /** POSIX TZ strings for the zones the home screen displays. */
+    inline constexpr const char* TZ_ARIZONA = "MST7";
+    inline constexpr const char* TZ_PACIFIC = "PST8PDT,M3.2.0,M11.1.0";
+}

--- a/firmware/include/ui/home_screen.h
+++ b/firmware/include/ui/home_screen.h
@@ -16,6 +16,7 @@ private:
     /* Clock widget */
     lv_obj_t* _lblClock    = nullptr;
     lv_obj_t* _lblDate     = nullptr;
+    lv_obj_t* _lblOtherTz  = nullptr;   // "AZ  5:47 PM    PT  5:47 PM" — issue #258
     lv_timer_t* _clockTimer = nullptr;
 
     /* Appointments card — up to 3 compact event rows */

--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SHARED_SRCS
     "data_service.cpp"
     "ha_command.cpp"
     "ntp_time.cpp"
+    "time_helpers.cpp"
     "logger.cpp"
     "error_state.cpp"
     "staleness_tracker.cpp"

--- a/firmware/src/time_helpers.cpp
+++ b/firmware/src/time_helpers.cpp
@@ -1,0 +1,42 @@
+/**
+ * Time Helpers implementation — see time_helpers.h for contract.
+ */
+
+#include "time_helpers.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+void TimeHelpers::formatNow12h(const char* posixTz, char* outBuf, size_t bufLen)
+{
+    if (!outBuf || bufLen == 0 || !posixTz) return;
+
+    /* Save current process TZ so we can restore it. */
+    const char* prevTz = getenv("TZ");
+    char savedTz[64] = {0};
+    bool hadPrev = false;
+    if (prevTz) {
+        strncpy(savedTz, prevTz, sizeof(savedTz) - 1);
+        hadPrev = true;
+    }
+
+    /* Switch TZ, format, restore. */
+    setenv("TZ", posixTz, 1);
+    tzset();
+
+    time_t now = time(nullptr);
+    struct tm tmInTz;
+    localtime_r(&now, &tmInTz);
+
+    int h = tmInTz.tm_hour % 12;
+    if (h == 0) h = 12;
+    const char* ampm = (tmInTz.tm_hour < 12) ? "AM" : "PM";
+    snprintf(outBuf, bufLen, "%d:%02d %s", h, tmInTz.tm_min, ampm);
+
+    if (hadPrev) {
+        setenv("TZ", savedTz, 1);
+    } else {
+        unsetenv("TZ");
+    }
+    tzset();
+}

--- a/firmware/src/ui/home_screen.cpp
+++ b/firmware/src/ui/home_screen.cpp
@@ -12,6 +12,7 @@
 #include "ntp_time.h"
 #include "config_store.h"
 #include "logger.h"
+#include "time_helpers.h"   // multi-TZ formatter (issue #258)
 
 static const lv_color_t BG_COLOR     = lv_color_hex(0x0f0f23);
 static const lv_color_t CARD_BG      = lv_color_hex(0x1a1a2e);
@@ -63,6 +64,13 @@ void HomeScreen::createClock(lv_obj_t* parent) {
     lv_obj_set_style_text_color(_lblDate, TEXT_SECONDARY, 0);
     lv_obj_align(_lblDate, LV_ALIGN_TOP_LEFT, 0, SY(75));
     lv_label_set_text(_lblDate, "---");
+
+    /* Other-timezone strip — AZ + PT under the date (issue #258). */
+    _lblOtherTz = lv_label_create(area);
+    lv_obj_set_style_text_font(_lblOtherTz, &lv_font_montserrat_20, 0);
+    lv_obj_set_style_text_color(_lblOtherTz, TEXT_SECONDARY, 0);
+    lv_obj_align(_lblOtherTz, LV_ALIGN_TOP_LEFT, 0, SY(108));
+    lv_label_set_text(_lblOtherTz, "");
 }
 
 void HomeScreen::updateClock() {
@@ -78,6 +86,20 @@ void HomeScreen::updateClock() {
     const char* d = NtpTime::dateStr();
     if (strcmp(lv_label_get_text(_lblDate), d) != 0) {
         lv_label_set_text(_lblDate, d);
+    }
+
+    /* AZ + PT strip (issue #258). Build new string and compare before
+       setting to preserve the "only update when changed" pattern. */
+    if (_lblOtherTz && NtpTime::isSynced()) {
+        char az[12] = {0};
+        char pt[12] = {0};
+        TimeHelpers::formatNow12h(TimeHelpers::TZ_ARIZONA, az, sizeof(az));
+        TimeHelpers::formatNow12h(TimeHelpers::TZ_PACIFIC, pt, sizeof(pt));
+        char line[48];
+        snprintf(line, sizeof(line), "AZ  %s    PT  %s", az, pt);
+        if (strcmp(lv_label_get_text(_lblOtherTz), line) != 0) {
+            lv_label_set_text(_lblOtherTz, line);
+        }
     }
 }
 


### PR DESCRIPTION
## Epic summary
Display Arizona and Pacific time under the date on the home screen, alongside the existing local-time clock. Resolves the "what time is it for them right now?" question without mental math when working with collaborators in MST and PT.

## Layout
\`\`\`
  8:47 PM
  Wednesday, May 17
  AZ  5:47 PM    PT  5:47 PM
\`\`\`

## Stories landed
- HTZ.1 #257 — \`TimeHelpers::formatNow12h(posixTz, outBuf, bufLen)\` helper (sets process TZ via setenv/tzset, formats current time as 12-hour "H:MM AM/PM", restores prior TZ)
- HTZ.2 #258 — home screen \`_lblOtherTz\` label under existing date, refreshed in \`updateClock()\` tick, gated on \`NtpTime::isSynced()\`. 20pt Montserrat (user-verified as readable).
- HTZ.3 #259 — flash + visual verification on dcc-panel7 ✓; dcc-desk deferred (device not currently connected — same firmware passes \`crowpanel5\` build so no regression expected).

## Verification
- [x] \`pio run -e crowpanel5\`: clean
- [x] \`pio run -e crowpanel7\`: clean (CMakeLists.txt updated to include time_helpers.cpp in P4 ESP-IDF build)
- [x] dcc-panel7 flashed and visually confirmed: AZ + PT line readable, times correctly offset from local Eastern
- [ ] dcc-desk visual verification: deferred until device reconnected

Closes #260, closes #257, closes #258, closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)