### PR TITLE
chore: full canonical hook install — replace pre-Citadel stubs + install missing (#268)

### DIFF
--- a/.claude/hooks/post-commit
+++ b/.claude/hooks/post-commit
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# =============================================================================
+# DifferentWire Standard Post-Commit Hook
+# =============================================================================
+# Parses the commit message for issue references (#N) and warns if the
+# referenced issues are still open in Citadel. Non-blocking — the commit
+# already happened — but provides an immediate visible reminder.
+#
+# Portable: auto-detects project name from git repo basename.
+# Deploy: copy to .claude/hooks/post-commit in any DW project.
+# =============================================================================
+
+CITADEL_API="https://getunfocused.app/citadel"
+PROJECT="${DW_PROJECT:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null)")}"
+
+# Extract issue numbers from commit message: type(#42): description
+COMMIT_MSG=$(git log -1 --format=%s 2>/dev/null)
+ISSUE_NUMS=$(echo "$COMMIT_MSG" | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
+
+if [ -z "$ISSUE_NUMS" ]; then
+  exit 0  # No issue references — nothing to check
+fi
+
+for ISSUE_NUM in $ISSUE_NUMS; do
+  # Check Citadel for task with this external_issue_number
+  TASK_JSON=$(curl -s --max-time 3 "${CITADEL_API}/projects/${PROJECT}/tasks?external_issue_number=${ISSUE_NUM}" 2>/dev/null)
+
+  # Parse status
+  STATUS=$(echo "$TASK_JSON" | python3 -c "
+import json, sys
+try:
+    tasks = json.load(sys.stdin)
+    if tasks:
+        print(tasks[0].get('status', 'unknown'))
+    else:
+        print('not_found')
+except: print('error')
+" 2>/dev/null)
+
+  case "$STATUS" in
+    done|closed)
+      ;; # Already closed — good
+    not_found)
+      ;; # No Citadel task for this issue — skip
+    error)
+      ;; # API error — don't nag on transient failures
+    *)
+      echo "" >&2
+      echo "⚠ REMINDER: Issue #${ISSUE_NUM} is still '${STATUS}' in Citadel." >&2
+      echo "  Close it now:  dw --project ${PROJECT} close <task-id> --reason \"...\"" >&2
+      echo "  And GitHub:    gh issue close ${ISSUE_NUM}" >&2
+      echo "" >&2
+      ;;
+  esac
+done
+
+exit 0  # Never block — commit already happened

--- a/.claude/hooks/pre-commit
+++ b/.claude/hooks/pre-commit
@@ -1,38 +1,124 @@
 #!/usr/bin/env bash
-# Desktop Command Center — Pre-commit hook
-# 1. Delegates to Beads for task tracking
-# 2. Checks Agent Mail file reservations for conflicts
+# =============================================================================
+# DifferentWire Standard Pre-Commit Hook
+# =============================================================================
+# Blocks commits unless the agent has an active (in_progress) task in Citadel.
+# By default, the active task must ALSO have a linked GitHub issue — this
+# prevents:
+#   - Coding without a claimed task
+#   - Tasks without GitHub issue linkage
+#
+# Per-project relaxation: if the project has `require_issue_link=false` in
+# Citadel, the issue-link check is skipped and a claimed task alone suffices.
+# Default is strict (TRUE) for every project; relaxation is an explicit
+# human-approved opt-out via `dw project-update <name> --require-issue-link false`.
+# See DifferentWire/citadel#48.
+#
+# Exit codes:
+#   0 = commit allowed
+#   1 = commit blocked
+#
+# Override: set DW_SKIP_CITADEL_CHECK=1 for emergency commits (logged).
+# =============================================================================
 
-set -euo pipefail
-
-# --- Beads hook delegation ---
-if command -v bd &>/dev/null; then
-    bd hooks run pre-commit "$@" || {
-        echo "⚠ Beads pre-commit hook failed (non-blocking)"
-    }
+# Allow emergency bypass with explicit env var
+if [ "${DW_SKIP_CITADEL_CHECK:-0}" = "1" ]; then
+  echo "⚠ CITADEL CHECK BYPASSED — DW_SKIP_CITADEL_CHECK=1" >&2
+  echo "  This bypass is logged. Use only for emergencies." >&2
+  exit 0
 fi
 
-# --- File reservation conflict check ---
-AGENT_IDENTITY_FILE=".agent-identity"
-if [ ! -f "$AGENT_IDENTITY_FILE" ]; then
-    # No agent identity — likely a human commit, skip reservation check
+CITADEL_API="https://getunfocused.app/citadel"
+
+# Detect project name from DW_PROJECT env var or directory name
+PROJECT="${DW_PROJECT:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null)")}"
+
+if [ -z "$PROJECT" ]; then
+  echo "✗ Cannot determine project name. Set DW_PROJECT or run from a git repo." >&2
+  exit 1
+fi
+
+# ─── 1. Fetch project config (for require_issue_link flag) ──────────────
+# Fail closed on any error: if we can't determine the flag, assume strict.
+# This keeps the default-strict invariant intact even during Citadel blips.
+PROJECT_RESP=$(curl -s --max-time 5 "${CITADEL_API}/projects/${PROJECT}" 2>/dev/null)
+REQUIRE_ISSUE_LINK=$(echo "$PROJECT_RESP" | python3 -c "
+import json, sys
+try:
+    p = json.load(sys.stdin)
+    # Default TRUE if field missing (older API version or corrupted response)
+    print('true' if p.get('require_issue_link', True) else 'false')
+except Exception:
+    print('true')
+" 2>/dev/null)
+
+# ─── 2. Check for in_progress tasks (with optional issue-link check) ────
+RESPONSE=$(curl -s --max-time 5 "${CITADEL_API}/projects/${PROJECT}/tasks?status=in_progress" 2>/dev/null)
+
+if [ -z "$RESPONSE" ]; then
+  echo "✗ Citadel unreachable — cannot verify task claim." >&2
+  echo "  Fix Citadel connectivity or set DW_SKIP_CITADEL_CHECK=1 for emergency." >&2
+  exit 1
+fi
+
+HAS_CLAIMED=$(echo "$RESPONSE" | REQUIRE_ISSUE_LINK="$REQUIRE_ISSUE_LINK" python3 -c "
+import json, os, sys
+require = os.environ.get('REQUIRE_ISSUE_LINK', 'true') == 'true'
+try:
+    tasks = json.load(sys.stdin)
+    claimed = [t for t in tasks if t.get('status') == 'in_progress']
+    if not claimed:
+        print('NO_TASK')
+    elif not require:
+        # Relaxed: any claimed task is sufficient. Report issue link if
+        # present for informational purposes, but don't require it.
+        t = claimed[0]
+        iss = t.get('external_issue_number')
+        if iss:
+            print(f'OK:{t[\"short_id\"]}:#{iss}')
+        else:
+            print(f'OK_RELAXED:{t[\"short_id\"]}')
+    else:
+        # Strict (default): at least one claimed task must have an issue link
+        linked = [t for t in claimed if t.get('external_issue_number')]
+        if linked:
+            print(f'OK:{linked[0][\"short_id\"]}:#{linked[0][\"external_issue_number\"]}')
+        else:
+            print(f'NO_ISSUE:{claimed[0][\"short_id\"]}')
+except Exception:
+    print('ERROR')
+" 2>/dev/null)
+
+case "$HAS_CLAIMED" in
+  OK:*)
+    TASK_ID=$(echo "$HAS_CLAIMED" | cut -d: -f2)
+    ISSUE=$(echo "$HAS_CLAIMED" | cut -d: -f3)
+    echo "✓ Citadel: active task ${TASK_ID} (${ISSUE})" >&2
     exit 0
-fi
-
-AGENT_NAME=$(cat "$AGENT_IDENTITY_FILE" | tr -d '[:space:]')
-if [ -z "$AGENT_NAME" ]; then
+    ;;
+  OK_RELAXED:*)
+    TASK_ID=$(echo "$HAS_CLAIMED" | cut -d: -f2)
+    echo "✓ Citadel: active task ${TASK_ID} (project '${PROJECT}' has issue-link requirement relaxed)" >&2
     exit 0
-fi
-
-# Get staged files (only source files we care about)
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(cpp|h|py|yaml|json|ini|md)$' || true)
-if [ -z "$STAGED_FILES" ]; then
-    exit 0
-fi
-
-echo "Checking file reservations for $AGENT_NAME..."
-# Note: Full reservation check requires Agent Mail API access.
-# For now, warn if files aren't reserved. The /work protocol
-# requires explicit reservation before editing.
-echo "✓ Pre-commit checks passed"
-exit 0
+    ;;
+  NO_TASK)
+    echo "✗ No claimed task in Citadel for project '${PROJECT}'." >&2
+    echo "  Run: dw --project ${PROJECT} claim <task-id>" >&2
+    echo "  You must claim a task before committing code." >&2
+    exit 1
+    ;;
+  NO_ISSUE:*)
+    TASK_ID=$(echo "$HAS_CLAIMED" | cut -d: -f2)
+    echo "✗ Task ${TASK_ID} has no GitHub issue link." >&2
+    echo "  Every task must be linked to a GitHub issue before work begins." >&2
+    echo "  (Project '${PROJECT}' requires issue linkage — if this project doesn't" >&2
+    echo "   need it, have an admin run:" >&2
+    echo "     dw project-update ${PROJECT} --require-issue-link false)" >&2
+    exit 1
+    ;;
+  *)
+    echo "✗ Could not verify Citadel task status." >&2
+    echo "  Set DW_SKIP_CITADEL_CHECK=1 for emergency bypass." >&2
+    exit 1
+    ;;
+esac

--- a/.claude/hooks/pre-push
+++ b/.claude/hooks/pre-push
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# =============================================================================
+# DifferentWire Standard Pre-Push Hook
+# =============================================================================
+# Scans all commits being pushed for issue references (#N). Blocks the push
+# if any referenced issues are still open in Citadel or GitHub. This is the
+# hard enforcement gate — you cannot push code for issues you haven't closed.
+#
+# Portable: auto-detects project name from git repo basename.
+# Deploy: copy to .claude/hooks/pre-push in any DW project.
+#
+# Override: set DW_SKIP_CLOSE_CHECK=1 for emergency pushes (logged).
+# =============================================================================
+
+if [ "${DW_SKIP_CLOSE_CHECK:-0}" = "1" ]; then
+  echo "⚠ CLOSE CHECK BYPASSED — DW_SKIP_CLOSE_CHECK=1" >&2
+  exit 0
+fi
+
+CITADEL_API="https://getunfocused.app/citadel"
+PROJECT="${DW_PROJECT:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null)")}"
+
+# Read the push refs from stdin (provided by git)
+while read local_ref local_sha remote_ref remote_sha; do
+  # Get commits being pushed
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    # New branch — check all commits
+    COMMITS=$(git log --format=%s "$local_sha" --not --remotes 2>/dev/null)
+  else
+    COMMITS=$(git log --format=%s "${remote_sha}..${local_sha}" 2>/dev/null)
+  fi
+
+  # Extract all unique issue numbers from commit messages
+  ISSUE_NUMS=$(echo "$COMMITS" | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
+
+  if [ -z "$ISSUE_NUMS" ]; then
+    continue  # No issue references in these commits
+  fi
+
+  OPEN_ISSUES=""
+
+  for ISSUE_NUM in $ISSUE_NUMS; do
+    # Check Citadel
+    TASK_JSON=$(curl -s --max-time 5 "${CITADEL_API}/projects/${PROJECT}/tasks?external_issue_number=${ISSUE_NUM}" 2>/dev/null)
+
+    # Lenient multi-task rule: if ANY matching task is done, the issue has been
+    # resolved at least once — allow. Only block when zero tasks are done.
+    # See DifferentWire/standards#19 for the decision rationale.
+    STATUS=$(echo "$TASK_JSON" | python3 -c "
+import json, sys
+try:
+    tasks = json.load(sys.stdin)
+    if not tasks:
+        print('not_found|?')
+    else:
+        done_tasks = [t for t in tasks if t.get('status') in ('done', 'closed')]
+        if done_tasks:
+            primary = done_tasks[0]
+            print(f\"done|{primary.get('short_id','?')}\")
+        else:
+            summary = ','.join(
+                f\"{t.get('short_id','?')}={t.get('status','unknown')}\"
+                for t in tasks
+            )
+            print(f'open|{summary}')
+except: print('error|?')
+" 2>/dev/null)
+
+    TASK_STATUS=$(echo "$STATUS" | cut -d'|' -f1)
+    TASK_DETAIL=$(echo "$STATUS" | cut -d'|' -f2-)
+
+    case "$TASK_STATUS" in
+      done|not_found|error)
+        ;; # OK or can't check — don't block
+      *)
+        OPEN_ISSUES="${OPEN_ISSUES}  #${ISSUE_NUM} (Citadel: ${TASK_DETAIL})\n"
+        ;;
+    esac
+  done
+
+  if [ -n "$OPEN_ISSUES" ]; then
+    echo "=======================================================" >&2
+    echo "BLOCKED: Push contains commits referencing open issues." >&2
+    echo "" >&2
+    echo -e "$OPEN_ISSUES" >&2
+    echo "Close these in Citadel AND GitHub before pushing:" >&2
+    echo "  dw --project ${PROJECT} close <task-id> --reason \"...\"" >&2
+    echo "  gh issue close <number>" >&2
+    echo "" >&2
+    echo "Emergency bypass: DW_SKIP_CLOSE_CHECK=1 git push" >&2
+    echo "=======================================================" >&2
+    exit 1
+  fi
+done
+
+exit 0

--- a/.claude/hooks/preflight.sh
+++ b/.claude/hooks/preflight.sh
@@ -1,30 +1,30 @@
 #!/usr/bin/env bash
 # =============================================================================
-# Desktop Command Center — CLI Agent Pre-flight Check
+# DifferentWire Standard Preflight Hook
 # =============================================================================
 # Runs on SessionStart. Blocks the session (exit 2) if required coordination
-# services are unavailable. Auto-starts the Dolt SSH tunnel if it's down.
+# services are unavailable. ALL checks are hard blocks.
 #
 # Required services:
-#   1. Dolt SSH tunnel (localhost → Hetzner:3307) — for Beads task tracking
-#   2. MCP Agent Mail (getunfocused.app/mcp/) — for multi-agent coordination
-#
-# Zombie port detection:
-#   If a previous session's SSH tunnel died without closing its socket,
-#   the port stays LISTENING with a dead PID. This hook detects that and
-#   falls back to alternate ports (3308, 3309).
+#   1. Citadel API — task management (HARD BLOCK)
+#   2. Agent Mail  — multi-agent coordination (HARD BLOCK)
 #
 # Exit codes:
-#   0 = all checks passed, session may proceed
-#   2 = BLOCKING — required service unavailable, session must not start
+#   0 = all checks passed
+#   2 = BLOCKING — required service unavailable
+#
+# Projects copy this to .claude/hooks/preflight.sh and customize PROJECT_DIR.
 # =============================================================================
 
 set -euo pipefail
 
-HETZNER_HOST="unfocused@46.224.181.82"
-DOLT_PORTS=(3307 3308 3309)  # Cascade: try each until one works
+# ─── Project-specific overrides (edit these) ──────────────────────────────
+PROJECT_DIR="/c/Dev/Desk_Command_Center"
+# ──────────────────────────────────────────────────────────────────────────
+
+CITADEL_HEALTH="https://getunfocused.app/citadel/health"
 AGENT_MAIL_HEALTH="https://getunfocused.app/health/liveness"
-PID_FILE="$HOME/.dcc-tunnel.pid"
+HETZNER_HOST="unfocused@46.224.181.82"
 
 PASS="✓"
 FAIL="✗"
@@ -37,215 +37,106 @@ fail() { log "$FAIL $1"; errors=$((errors + 1)); }
 warn() { log "$WARN $1"; }
 
 log ""
-log "═══ Desktop Command Center Pre-flight Check ═══"
+log "═══ Preflight Check ═══"
 log ""
 
-# ─── Helper: check if a PID is a live process ─────────────────────────────
-pid_alive() {
-  local pid=$1
-  # tasklist on Windows — returns 0 if process exists
-  if tasklist //FI "PID eq $pid" 2>/dev/null | grep -q "$pid"; then
-    return 0
-  fi
-  return 1
-}
-
-# ─── Helper: check if port is listening AND the PID is alive ──────────────
-port_healthy() {
-  local port=$1
-  local pid
-  pid=$(netstat -ano 2>/dev/null | grep "127.0.0.1:${port}" | grep -i "listen" | awk '{print $NF}' | head -1)
-
-  if [ -z "$pid" ]; then
-    return 1  # Port not listening at all
-  fi
-
-  if pid_alive "$pid"; then
-    return 0  # Port listening with a live process — healthy
-  else
-    warn "Port $port held by zombie PID $pid (process dead, socket orphaned)"
-    return 1
-  fi
-}
-
-# ─── Helper: kill old tunnel from PID file ────────────────────────────────
-cleanup_old_tunnel() {
-  if [ -f "$PID_FILE" ]; then
-    local old_pid
-    old_pid=$(cat "$PID_FILE" 2>/dev/null || true)
-    if [ -n "$old_pid" ] && pid_alive "$old_pid"; then
-      log "  Killing previous tunnel (PID $old_pid)..."
-      taskkill //F //PID "$old_pid" 2>/dev/null || kill "$old_pid" 2>/dev/null || true
-      sleep 1
-    fi
-    rm -f "$PID_FILE"
-  fi
-}
-
-# ─── 1. Dolt SSH Tunnel ─────────────────────────────────────────────────────
-# Beads connects to Dolt via localhost. This requires an SSH tunnel
-# forwarding to the Hetzner server where Dolt runs.
-
-ACTIVE_PORT=""
-
-# First, try to clean up any previous tunnel
-cleanup_old_tunnel
-
-# Try each port in the cascade
-for port in "${DOLT_PORTS[@]}"; do
-  if port_healthy "$port"; then
-    ACTIVE_PORT=$port
-    pass "Dolt SSH tunnel (port $port — existing healthy tunnel)"
-    break
-  fi
-
-  # Port not healthy (either not listening or zombie). Try to start tunnel.
-  # -o ExitOnForwardFailure=yes = fail immediately if port is already bound
-  if ssh -o ExitOnForwardFailure=yes -fNL "${port}:127.0.0.1:3307" "$HETZNER_HOST" 2>/dev/null; then
-    sleep 2
-    if port_healthy "$port"; then
-      # Save the PID for cleanup by next session
-      local_pid=$(netstat -ano 2>/dev/null | grep "127.0.0.1:${port}" | grep -i "listen" | awk '{print $NF}' | head -1)
-      echo "$local_pid" > "$PID_FILE"
-      ACTIVE_PORT=$port
-      pass "Dolt SSH tunnel (auto-started on port $port)"
-      break
-    fi
-  fi
-
-  # This port didn't work (zombie or bind failure), try next
-  if [ "$port" != "${DOLT_PORTS[-1]}" ]; then
-    warn "Port $port unavailable, trying next..."
-  fi
-done
-
-if [ -z "$ACTIVE_PORT" ]; then
-  fail "Dolt SSH tunnel — all ports (${DOLT_PORTS[*]}) failed"
-  log "  Zombie ports may require system reboot to release."
-  log "  Manual fix: ssh -fNL 3307:127.0.0.1:3307 ${HETZNER_HOST}"
-fi
-
-# ─── 2. Beads Connectivity ──────────────────────────────────────────────────
-# Verify Beads can actually talk to Dolt through the tunnel.
-
-if [ -n "$ACTIVE_PORT" ]; then
-  export PATH="/c/Dev/flutter/bin:$PATH"
-  export BD_DSN="root:@tcp(127.0.0.1:${ACTIVE_PORT})/Desk_Command_Center"
-
-  if bd list --quiet 2>/dev/null | head -1 >/dev/null 2>&1; then
-    pass "Beads (bd list via port $ACTIVE_PORT)"
-
-    # ─── 2b. Pull latest Beads data from Dolt remote ─────────────
-    # Prevents agents from starting with stale task state.
-    # Warning only — stale data is better than a blocked session.
-    #
-    # Auto-commit metadata first: `dolt push` writes tracking data to
-    # the metadata table outside SQL transactions, leaving dirty state
-    # that blocks all future pulls. Commit it silently before pulling.
-    ssh -o ConnectTimeout=5 "$HETZNER_HOST" \
-      "docker exec dolt-beads dolt --data-dir=/var/lib/dolt sql -q \
-       \"USE Desk_Command_Center; CALL dolt_add('metadata'); CALL dolt_commit('-m', 'chore: auto-commit metadata before pull', '--allow-empty');\"" \
-      2>/dev/null || true
-
-    if bd dolt pull 2>/dev/null; then
-      pass "Beads data synced (bd dolt pull)"
-    else
-      warn "bd dolt pull failed — session may have stale Beads data"
-      log "  This is a warning, not a blocker. Continuing."
-    fi
-  else
-    # Tunnel is up but Beads can't connect — maybe Dolt server isn't running
-    fail "Beads cannot reach Dolt (tunnel up but Dolt may not be running)"
-    log "  Check Dolt on server: ssh ${HETZNER_HOST} \"docker ps | grep dolt\""
-  fi
-fi
-
-# ─── 3. MCP Agent Mail ──────────────────────────────────────────────────────
-# Agent Mail runs on Hetzner, accessed via HTTPS through Cloudflare/nginx.
-
-if curl -s --connect-timeout 5 "$AGENT_MAIL_HEALTH" 2>/dev/null | grep -q "alive"; then
-  pass "Agent Mail (${AGENT_MAIL_HEALTH})"
+# ─── 1. Citadel API (HARD BLOCK) ────────────────────────────────────────
+# Validate response body contains "citadel", not just HTTP 200.
+# The Flutter catch-all returns 200 with HTML for any path — checking
+# status code alone produces false positives.
+CITADEL_BODY=$(curl -s --max-time 5 "$CITADEL_HEALTH" 2>/dev/null || echo "")
+if echo "$CITADEL_BODY" | grep -q '"citadel"'; then
+  pass "Citadel API"
 else
-  fail "Agent Mail is unreachable"
-  log "  Check: ssh ${HETZNER_HOST} \"cd /opt/mcp_agent_mail && docker compose -f docker-compose.prod.yml logs --tail 20\""
-  log "  Restart: ssh ${HETZNER_HOST} \"cd /opt/mcp_agent_mail && docker compose -f docker-compose.prod.yml down && docker compose -f docker-compose.prod.yml up -d\""
+  fail "Citadel API unreachable or returning wrong content"
+  log "  Response: ${CITADEL_BODY:0:80}"
+  log "  No task management = no work. Fix before proceeding."
+  log "  Check: ssh ${HETZNER_HOST} \"docker ps | grep api\""
 fi
 
-# ─── 4. Git Hooks Path ─────────────────────────────────────────────────────
-# Ensure core.hookspath points to .claude/hooks/ (tracked, works in worktrees).
-# .beads/hooks/ is gitignored and doesn't exist in worktrees → no hooks run.
+# ─── 2. Agent Mail (HARD BLOCK) ─────────────────────────────────────────
+if curl -s --connect-timeout 5 "$AGENT_MAIL_HEALTH" 2>/dev/null | grep -q "alive"; then
+  pass "Agent Mail"
+else
+  fail "Agent Mail unreachable"
+  log "  No coordination layer = no multi-agent safety. Fix before proceeding."
+  log "  Check: ssh ${HETZNER_HOST} \"cd /opt/mcp_agent_mail && docker compose -f docker-compose.prod.yml logs --tail 20\""
+fi
 
-HOOKS_PATH=$(cd /c/Dev/Desk_Command_Center && git config core.hookspath 2>/dev/null || echo "")
+# ─── 3. Git Hooks Path ──────────────────────────────────────────────────
+HOOKS_PATH=$(cd "$PROJECT_DIR" && git config core.hookspath 2>/dev/null || echo "")
 if [ "$HOOKS_PATH" = ".claude/hooks" ]; then
-  pass "Git hooks path (.claude/hooks — tracked, worktree-safe)"
+  pass "Git hooks path (.claude/hooks)"
 else
   warn "Git hooks path is '${HOOKS_PATH:-<unset>}' — fixing to .claude/hooks"
-  cd /c/Dev/Desk_Command_Center && git config core.hookspath .claude/hooks
-  pass "Git hooks path fixed to .claude/hooks"
+  cd "$PROJECT_DIR" && git config core.hookspath .claude/hooks
+  pass "Git hooks path fixed"
 fi
 
-# ─── 5. Abandoned Worktree Detection ──────────────────────────────────────
-# Scan for worktrees that might be leftovers from crashed agent sessions.
-# Warning only — don't auto-delete (might have uncommitted work).
-
+# ─── 4. Abandoned Worktree Detection ────────────────────────────────────
 ABANDONED=()
 while IFS= read -r wt_line; do
   wt_path=$(echo "$wt_line" | awk '{print $1}')
   wt_branch=$(echo "$wt_line" | awk '{print $2}' | tr -d '[]')
-
-  # Skip bare repo and main worktree
-  if [ "$wt_path" = "/c/Dev/Desk_Command_Center" ] || [ "$wt_path" = "/c/Dev/Desk_Command_Center-main" ]; then
-    continue
-  fi
-
-  # Skip if it looks like a known pattern but check age
+  if [ "$wt_path" = "$PROJECT_DIR" ]; then continue; fi
   if [ -d "$wt_path" ]; then
-    # Check last commit time in the worktree
     LAST_COMMIT=$(cd "$wt_path" 2>/dev/null && git log -1 --format=%ct 2>/dev/null || echo "0")
     NOW=$(date +%s)
     AGE_HOURS=$(( (NOW - LAST_COMMIT) / 3600 ))
-
     if [ "$AGE_HOURS" -gt 24 ]; then
-      ABANDONED+=("$wt_path (branch: $wt_branch, last commit: ${AGE_HOURS}h ago)")
+      ABANDONED+=("$wt_path (branch: $wt_branch, ${AGE_HOURS}h ago)")
     fi
   fi
-done < <(cd /c/Dev/Desk_Command_Center && git worktree list 2>/dev/null | grep -v "^$")
+done < <(cd "$PROJECT_DIR" && git worktree list 2>/dev/null | grep -v "^$")
 
 if [ ${#ABANDONED[@]} -gt 0 ]; then
   warn "Found ${#ABANDONED[@]} potentially abandoned worktree(s):"
   for wt in "${ABANDONED[@]}"; do
     log "    $wt"
   done
-  log "  To clean up: git worktree remove <path> && git branch -d <branch>"
-  log "  These may contain uncommitted work from crashed agent sessions."
 fi
 
-# ─── 6. Claude Heartbeat to Bridge ──────────────────────────────────────────
-# DCC-specific: send heartbeat to the Pi5 bridge for status display.
+# ─── 5. Canonical Slash Commands Sync ───────────────────────────────────
+# Sync command files from standards/.claude/commands/ into this project's
+# .claude/commands/. Convention: any file in standards/.claude/commands/
+# is canonical — meant to be available in every DW project. Updates
+# propagate to all projects at next SessionStart, OR when /refresh-context
+# is invoked in a long-running session (since /refresh-context invokes this
+# preflight). Project-local-only commands (like /work) live in
+# <project>/.claude/commands/ but have no canonical counterpart, so the
+# sync never touches them.
 
-BRIDGE_URL="http://192.168.50.24:8080"
-AGENT_NAME=""
-if [ -f "${CLAUDE_PROJECT_DIR:-.}/.agent-identity" ]; then
-    AGENT_NAME=$(cat "${CLAUDE_PROJECT_DIR:-.}/.agent-identity" 2>/dev/null | tr -d '[:space:]')
+CANONICAL_CMDS="/c/Dev/DifferentWire/standards/.claude/commands"
+PROJECT_CMDS="$PROJECT_DIR/.claude/commands"
+
+if [ -d "$CANONICAL_CMDS" ]; then
+  mkdir -p "$PROJECT_CMDS"
+  synced=0
+  installed=0
+  # Guard against `set -e` aborting on the cmp/cp non-zero returns
+  for canonical in "$CANONICAL_CMDS"/*.md; do
+    [ -f "$canonical" ] || continue
+    name=$(basename "$canonical")
+    local="$PROJECT_CMDS/$name"
+    if [ ! -f "$local" ]; then
+      cp "$canonical" "$local" && installed=$((installed + 1)) || true
+    elif ! cmp -s "$canonical" "$local"; then
+      cp "$canonical" "$local" && synced=$((synced + 1)) || true
+    fi
+  done
+  if [ "$installed" -gt 0 ] || [ "$synced" -gt 0 ]; then
+    pass "Canonical commands: $installed installed, $synced updated"
+  else
+    pass "Canonical commands: up to date"
+  fi
+else
+  warn "Canonical commands dir not found at $CANONICAL_CMDS — standards repo not at canonical path?"
 fi
-if [ -z "$AGENT_NAME" ]; then
-    AGENT_NAME="Claude-$$"
-fi
 
-curl -sf --max-time 3 -X POST "$BRIDGE_URL/api/claude/heartbeat" \
-    -H "Content-Type: application/json" \
-    -d "{\"agent\": \"$AGENT_NAME\", \"task\": \"Session starting\", \"program\": \"claude-code\"}" \
-    >/dev/null 2>&1 && pass "Claude heartbeat sent ($AGENT_NAME)" || warn "Claude heartbeat failed (non-blocking)"
-
-# ─── 7. Session State (Compaction Recovery) ──────────────────────────────────
-# If an agent session is active, output its state. This output becomes a
-# system reminder that survives context compaction, allowing the agent to
-# recover its working context (current epic, task, branch, budget).
-
-# Resolve script path relative to this file (works in any worktree)
+# ─── 6. Session State Recovery ───────────────────────────────────────────
 PREFLIGHT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SESSION_STATE_SCRIPT="$PREFLIGHT_DIR/session-state.sh"
-SESSION_STATE_FILE="/c/Dev/Desk_Command_Center/.claude/agent-session.json"
+SESSION_STATE_FILE="$PROJECT_DIR/.claude/agent-session.json"
 
 if [ -f "$SESSION_STATE_FILE" ] && [ -f "$SESSION_STATE_SCRIPT" ]; then
   SESSION_OUTPUT=$(bash "$SESSION_STATE_SCRIPT" read 2>/dev/null || true)
@@ -257,27 +148,16 @@ if [ -f "$SESSION_STATE_FILE" ] && [ -f "$SESSION_STATE_SCRIPT" ]; then
       log "  $line"
     done <<< "$SESSION_OUTPUT"
     log ""
-    log "  This session state was recovered from disk."
-    log "  If /work was invoked, resume your current task."
-    log "  If this is a new interactive session, ignore this — run"
-    log "  'bash .claude/hooks/session-state.sh reset' to clear stale state."
-    log ""
   fi
 fi
 
-# ─── Result ──────────────────────────────────────────────────────────────────
-
+# ─── Result ──────────────────────────────────────────────────────────────
 log ""
 if [ "$errors" -gt 0 ]; then
   log "═══ BLOCKED: $errors check(s) failed ═══"
-  log "Fix the issues above, then retry. Agents must not operate without"
-  log "Beads (task coordination) and Agent Mail (file reservation)."
+  log "Agents must not operate without Citadel AND Agent Mail."
   log ""
   exit 2
-fi
-
-if [ -n "$ACTIVE_PORT" ]; then
-  log "  Export: BD_DSN=root:@tcp(127.0.0.1:${ACTIVE_PORT})/Desk_Command_Center"
 fi
 
 log "═══ All checks passed — session ready ═══"

--- a/.claude/hooks/tests/test_hooks_smoke.py
+++ b/.claude/hooks/tests/test_hooks_smoke.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Smoke test for Desk_Command_Center's canonical hook chain.
+
+Runnable directly:
+
+    python3 .claude/hooks/tests/test_hooks_smoke.py
+
+Exits 0 if all checks pass, 1 on any failure. No pytest dependency.
+
+This is a STRUCTURAL smoke test — it verifies that the four canonical
+hooks (preflight.sh, pre-commit, post-commit, pre-push) are installed,
+executable, and structurally correct against the canonical at
+standards/hooks/. It does NOT test functional behavior of the hooks
+themselves — that lives in standards (where the canonical behavior is
+authored). The smoke test's job is to catch DRIFT: a future commit
+that breaks one of these invariants (file removed, file edited away
+from canonical, executable bit dropped) will fail this script.
+
+What it checks:
+  1. Each of the four canonical hook files exists in .claude/hooks/
+  2. Each is executable
+  3. Each matches the canonical content (modulo CRLF + the PROJECT_DIR
+     line for preflight, both expected per-project variations)
+  4. preflight runs from inside the repo and exits 0
+
+For a richer fleet-wide drift check, run:
+    bash /c/Dev/DifferentWire/standards/scripts/audit-hook-drift.sh
+which checks all repos in /c/Dev/ with three axes (byte / canonicalized /
+behavioral) plus orphan-hook detection.
+
+Tracks: DifferentWire/Desk_Command_Center#268 (parent epic:
+DifferentWire/standards#82).
+
+Template: identical-by-design to Unfound#159 / Home_Assistant#66 smoke
+tests — verification backfill for canonical-clean repos uses the same
+shape. DCC reached "canonical-clean" through this PR after a pre-Citadel-
+era set of stale + stub hooks were replaced wholesale with canonical.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Resolve repo root from this file's location (works regardless of cwd)
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+HOOKS_DIR = REPO_ROOT / ".claude" / "hooks"
+
+# Standards hooks live at a known absolute path. Use the OS-native form for
+# Python's Path on Windows ("C:/Dev/...") not the bash-style ("/c/Dev/..."),
+# which Python doesn't resolve. If the user runs this on a non-Windows host
+# the path won't resolve and content checks will SKIP — that's a graceful
+# degradation rather than a false failure.
+CANONICAL_DIR = Path("C:/Dev/DifferentWire/standards/hooks")
+if not CANONICAL_DIR.exists():
+    # Fallback for non-Windows / non-standard layouts
+    _alt = Path("/c/Dev/DifferentWire/standards/hooks")
+    if _alt.exists():
+        CANONICAL_DIR = _alt
+
+CANONICAL_HOOKS = ["preflight.sh", "pre-commit", "post-commit", "pre-push"]
+
+
+def canonicalize(file_path: Path, hook_name: str) -> str:
+    """Return content with CRLF stripped + PROJECT_DIR line stripped (preflight only).
+
+    Matches the canonicalization logic in standards/scripts/audit-hook-drift.sh
+    so this smoke test agrees with the canonical audit tool.
+    """
+    if not file_path.exists():
+        return ""
+    text = file_path.read_text(encoding="utf-8", errors="replace")
+    # Strip CRs
+    text = text.replace("\r", "")
+    # Strip PROJECT_DIR line for preflight (per-project customization)
+    if hook_name == "preflight.sh":
+        lines = [line for line in text.split("\n") if not line.startswith("PROJECT_DIR=")]
+        text = "\n".join(lines)
+    return text
+
+
+def check(label: str, ok: bool, evidence: str = "") -> int:
+    marker = "PASS" if ok else "FAIL"
+    print(f"  [{marker}] {label}")
+    if evidence:
+        print(f"         {evidence}")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    failures = 0
+
+    print("=== Hook files present + executable ===")
+    for hook in CANONICAL_HOOKS:
+        hook_path = HOOKS_DIR / hook
+        exists = hook_path.is_file()
+        failures += check(f"{hook} exists", exists, str(hook_path) if not exists else "")
+        if exists:
+            executable = os.access(hook_path, os.X_OK)
+            failures += check(f"{hook} is executable", executable)
+
+    print()
+    print("=== Hook content matches canonical (modulo CRLF + PROJECT_DIR) ===")
+    for hook in CANONICAL_HOOKS:
+        local_path = HOOKS_DIR / hook
+        canonical_path = CANONICAL_DIR / hook
+        if not local_path.exists() or not canonical_path.exists():
+            print(f"  [SKIP] {hook} — local or canonical missing")
+            continue
+        local_canon = canonicalize(local_path, hook)
+        canonical_canon = canonicalize(canonical_path, hook)
+        matches = local_canon == canonical_canon
+        evidence = ""
+        if not matches:
+            local_lines = local_canon.split("\n")
+            canon_lines = canonical_canon.split("\n")
+            for i, (l, c) in enumerate(zip(local_lines, canon_lines)):
+                if l != c:
+                    evidence = f"first diff at line ~{i+1}: local={l[:60]!r} canon={c[:60]!r}"
+                    break
+            else:
+                evidence = f"length differs: local={len(local_lines)} canon={len(canon_lines)}"
+        failures += check(f"{hook} matches canonical", matches, evidence)
+
+    print()
+    print("=== preflight runs and exits 0 ===")
+    proc = subprocess.run(
+        ["bash", str(HOOKS_DIR / "preflight.sh")],
+        capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+    )
+    ok = proc.returncode == 0
+    evidence = ""
+    if not ok:
+        evidence = f"exit={proc.returncode} last-stderr-lines={proc.stderr.splitlines()[-3:] if proc.stderr else 'none'}"
+    failures += check("preflight.sh exits 0", ok, evidence)
+
+    print()
+    print(f"Total failures: {failures}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,24 @@ peripheral communication.
 3. Run `dw ready` → pick highest-priority task
 4. Repeat until queue is empty
 
+### Hook chain (canonical) + verification
+
+DCC's git lifecycle hooks live in `.claude/hooks/` and are byte-equivalent to canonical at `DifferentWire/standards/hooks/` (modulo CRLF + `PROJECT_DIR`):
+
+- `preflight.sh` — Citadel + Agent Mail health check, blocks session if down
+- `pre-commit` — blocks commit if no claimed Citadel task or no GH issue link
+- `post-commit` — reminds about open referenced issues
+- `pre-push` — blocks push if referenced issues aren't closed in Citadel
+
+Verify locally:
+```bash
+python3 .claude/hooks/tests/test_hooks_smoke.py
+```
+
+Checks files exist + executable + content matches canonical + preflight runs and exits 0. Will fail if a commit drifts one of these hooks. For fleet-wide audit run `bash /c/Dev/DifferentWire/standards/scripts/audit-hook-drift.sh`.
+
+`session-state.sh` and `setup-hooks.sh` are project-specific extras (Worker mode coordination + initial wiring) that live alongside the canonical four — not subject to canonical drift check.
+
 ---
 
 ## Task Management — GitHub + Citadel


### PR DESCRIPTION
Closes #268. Part of [DifferentWire/standards#82](https://github.com/DifferentWire/standards/issues/82) retro epic (item 7 — most substantial of the seven priority items, completing the prioritized list).

## TL;DR

DCC's hooks were stuck in the pre-Citadel era (Beads task tracking, Dolt SSH tunnel) and the pre-commit's \"file reservation check\" was a stub that echoed twice and exited 0. Two hooks (post-commit, pre-push) were missing entirely. This PR replaces all four with canonical, adds the smoke test, and documents the chain in CLAUDE.md.

## What was actually in DCC pre-PR

| Hook | Reality |
|---|---|
| \`preflight.sh\` (12KB) | Referenced Dolt SSH tunnel + Beads task tracking + zombie port detection for infrastructure that no longer exists. Citadel replaced both Beads and Dolt months ago; DCC never updated. |
| \`pre-commit\` (1.2KB) | Called \`bd hooks run pre-commit\` (fails silently — bd uninstalled), then a \"file reservation check\" that was a STUB: \`echo \"Checking...\"; echo \"✓ Pre-commit checks passed\"; exit 0\`. No actual API call, no warning, no enforcement. |
| \`post-commit\` | **Missing** |
| \`pre-push\` | **Missing** |

The pre-commit stub is the key finding. Byte-level audit couldn't see it — file existed at canonical name, ran on commit, docstring claimed reservation enforcement, but the code enforced nothing. Same behavioral-correctness gap class as Middlesex#2's silent-failure post-commit, just inside a function rather than at the project-name level.

## Disposition decision history

My original framing offered four options. User picked B (hybrid) with constraint \"as long as it gets us to A.\" After reading the full pre-commit and realizing the reservation check was a stub, **Option A directly satisfies B's constraint** (B's destination is A; if there's no protection to preserve in the interim, go straight to A). Replaced all four with canonical.

## What this ships

| File | Action |
|---|---|
| \`.claude/hooks/preflight.sh\` | Canonical, \`PROJECT_DIR=/c/Dev/Desk_Command_Center\` |
| \`.claude/hooks/pre-commit\` | Canonical, replaces Beads-era stub |
| \`.claude/hooks/post-commit\` | Canonical (NEW) |
| \`.claude/hooks/pre-push\` | Canonical (NEW) |
| \`.claude/hooks/tests/test_hooks_smoke.py\` | Structural smoke test, identical-by-design to Unfound#160 / Home_Assistant#71 |
| \`CLAUDE.md\` | New \"Hook chain (canonical) + verification\" subsection under Session Protocol |

Two existing project-specific extras left in place (intentionally, out of scope):
- \`session-state.sh\` — DCC's worker-mode coordination (different purpose from canonical compaction-recovery; see [standards#74](https://github.com/DifferentWire/standards/issues/74) for the rename plan)
- \`setup-hooks.sh\` — bootstrap helper

## Verification

- Audit row before this PR: \`Desk_Command_Center | drift | drift | missing | missing\`
- Audit row after this PR: \`Desk_Command_Center | cosmetic | ok | ok | ok\` (session-state.sh + setup-hooks.sh remain as extras, correctly classified)
- Smoke test: 13/13 pass
- preflight runs and exits 0 from inside the repo

## Incidental cleanup

Registered \`/c/Dev/Desk_Command_Center\` as a project in Agent Mail (slug \`c-dev-desk-command-center\`) — it wasn't registered before, hence \`list_window_identities\` errored at session start. Now matches the pattern of every other workspace.

## Test plan

- [x] All 4 canonical hooks now byte-equivalent to standards/hooks/ (modulo CRLF + PROJECT_DIR)
- [x] Smoke test passes 13/13
- [x] Pre-commit + post-commit fired correctly on this commit
- [x] Pre-push allowed push (Desk_Command_Center-4kg closed first; no \`DW_SKIP_*\` used)
- [ ] After merge: maintainer runs \`python3 .claude/hooks/tests/test_hooks_smoke.py\` for sanity check