### PR TITLE
fix(#274): bound HA adapter payload (drop noise domains, cap fallback, fix WS frame)

### DIFF
--- a/bridge/adapters/home_assistant.py
+++ b/bridge/adapters/home_assistant.py
@@ -20,12 +20,19 @@ from .base import AdapterConfig, BaseAdapter
 
 logger = logging.getLogger(__name__)
 
-# Legacy fallback: entity domains shown when no DCC label is configured
+# Legacy fallback: entity domains shown when no DCC label is configured.
+# Deliberately EXCLUDES high-cardinality noise domains (sensor / binary_sensor):
+# large HA installs can carry 1000+ discovery sensors (e.g. BLE mesh contact
+# sensors) that bloat the payload and stall the device's single-core JSON parser.
+# Curated sensors are meant to arrive via the DCC label (label mode), not here.
 DISPLAY_DOMAINS = {
     "climate", "light", "switch", "lock", "cover",
-    "sensor", "binary_sensor", "person", "media_player",
-    "device_tracker",
+    "person", "media_player", "device_tracker",
 }
+
+# Hard backstop on fallback size so a future entity explosion in an allowed domain
+# can't balloon the payload again (the device parses the whole response on one core).
+MAX_FALLBACK_ENTITIES = 200
 
 
 class HomeAssistantAdapter(BaseAdapter):
@@ -130,7 +137,11 @@ class HomeAssistantAdapter(BaseAdapter):
         ws_url += "/api/websocket"
 
         try:
-            async with websockets.connect(ws_url) as ws:
+            # max_size=None: the entity registry response can exceed the
+            # websockets 1 MiB default frame limit on large HA installs. Without
+            # this the recv raises 1009 (message too big) and label mode silently
+            # degrades to the domain-mode fallback.
+            async with websockets.connect(ws_url, max_size=None) as ws:
                 # Step 1: Wait for auth_required
                 msg = json.loads(await ws.recv())
                 if msg.get("type") != "auth_required":
@@ -389,16 +400,28 @@ class HomeAssistantAdapter(BaseAdapter):
     def _parse_domain_mode(self, states: list) -> dict[str, Any]:
         """Legacy parse: filter by DISPLAY_DOMAINS, group by domain."""
         by_domain: dict[str, list[dict]] = {}
+        total = 0
+        capped = False
         for entity in states:
             entity_id = entity.get("entity_id", "")
             domain = entity_id.split(".")[0]
             if domain not in DISPLAY_DOMAINS:
                 continue
+            if total >= MAX_FALLBACK_ENTITIES:
+                capped = True
+                break
             parsed = self._parse_entity(entity, domain)
             by_domain.setdefault(domain, []).append(parsed)
+            total += 1
+
+        if capped:
+            logger.warning(
+                "HA: domain-mode fallback hit %d-entity cap — payload truncated; "
+                "configure a DCC label to curate entities", MAX_FALLBACK_ENTITIES,
+            )
 
         return {
             "label_mode": False,
             "domains": by_domain,
-            "total_entities": sum(len(v) for v in by_domain.values()),
+            "total_entities": total,
         }

--- a/bridge/tests/test_home_assistant.py
+++ b/bridge/tests/test_home_assistant.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from adapters import AdapterScheduler, AdapterStatus, TTLCache
-from adapters.home_assistant import HomeAssistantAdapter
+from adapters.home_assistant import MAX_FALLBACK_ENTITIES, HomeAssistantAdapter
 
 
 HA_CONFIG = {
@@ -179,13 +179,16 @@ class TestHomeAssistantAdapter:
         adapter = HomeAssistantAdapter(HA_CONFIG)
         parsed = adapter.parse(SAMPLE_RAW)
 
-        assert parsed["total_entities"] == 5  # automation filtered out
+        # sensor + automation excluded from the domain-mode fallback (#274)
+        assert parsed["total_entities"] == 4
         domains = parsed["domains"]
         assert "climate" in domains
-        assert "sensor" in domains
         assert "light" in domains
         assert "person" in domains
         assert "media_player" in domains
+        # high-cardinality noise domains are excluded from the fallback
+        assert "sensor" not in domains
+        assert "binary_sensor" not in domains
         assert "automation" not in domains
 
     def test_parse_climate_attrs(self):
@@ -199,10 +202,10 @@ class TestHomeAssistantAdapter:
         assert climate["hvac_action"] == "heating"
 
     def test_parse_sensor_attrs(self):
+        # Sensors are excluded from the domain-mode fallback (#274), but the
+        # entity parser still extracts their attributes (used in label mode).
         adapter = HomeAssistantAdapter(HA_CONFIG)
-        parsed = adapter.parse(SAMPLE_RAW)
-
-        sensor = parsed["domains"]["sensor"][0]
+        sensor = adapter._parse_entity(SAMPLE_RAW["states"][1], "sensor")
         assert sensor["unit"] == "°F"
         assert sensor["device_class"] == "temperature"
 
@@ -219,6 +222,16 @@ class TestHomeAssistantAdapter:
         parsed = adapter.parse({"states": []})
         assert parsed["total_entities"] == 0
         assert parsed["domains"] == {}
+
+    def test_domain_fallback_caps_entity_count(self):
+        # Backstop (#274): a large HA install can't balloon the fallback payload.
+        adapter = HomeAssistantAdapter(HA_CONFIG)
+        states = [
+            {"entity_id": f"switch.outlet_{i}", "state": "on", "attributes": {}}
+            for i in range(MAX_FALLBACK_ENTITIES + 50)
+        ]
+        parsed = adapter.parse({"states": states})
+        assert parsed["total_entities"] == MAX_FALLBACK_ENTITIES
 
     @pytest.mark.asyncio
     async def test_poll_requires_credentials(self):


### PR DESCRIPTION
Fixes the on-device screen flash: the bridge shipped a ~410 KB dashboard payload (1035 `binary_sensor` + 223 `sensor`) that the P4 parses on one core each poll (~11s), tripping the task watchdog **twice** per cycle. Flashes align 1:1 with poll cycles (serial vs observed, this session).

**Changes** (`bridge/adapters/home_assistant.py`):
- Drop `sensor`/`binary_sensor` from the domain-mode fallback (discovery noise; curated sensors come via the DCC label)
- `MAX_FALLBACK_ENTITIES=200` hard cap, WARN on truncation (no silent loss)
- `websockets.connect(max_size=None)` — registry frame exceeds the 1 MiB default (1009), which forced the unbounded fallback

Projected 410 KB → <160 KB; parse back under the 5s watchdog line. **168 tests pass.**

Deploy to the Pi + on-device verification is a separate gate; **#274 stays open until verified in production.**

Refs #274.